### PR TITLE
feat: structured message metadata — rich rendering for agent output

### DIFF
--- a/.scuttlebot.yaml
+++ b/.scuttlebot.yaml
@@ -1,0 +1,1 @@
+channel: scuttlebot

--- a/cmd/claude-relay/main.go
+++ b/cmd/claude-relay/main.go
@@ -343,8 +343,10 @@ func claudeSessionsRoot(cwd string) (string, error) {
 	return filepath.Join(home, ".claude", "projects", "-"+sanitized), nil
 }
 
-// findLatestSessionPath finds the most recently modified .jsonl file in root
-// that contains an entry with cwd matching targetCWD and timestamp after since.
+// findLatestSessionPath finds the .jsonl file in root whose first entry
+// timestamp is closest to (but after) since — this ensures each relay
+// latches onto its own subprocess's session rather than whichever file
+// happens to be most actively written to.
 func findLatestSessionPath(root, targetCWD string, since time.Time) (string, error) {
 	entries, err := os.ReadDir(root)
 	if err != nil {
@@ -352,8 +354,8 @@ func findLatestSessionPath(root, targetCWD string, since time.Time) (string, err
 	}
 
 	type candidate struct {
-		path    string
-		modTime time.Time
+		path       string
+		firstEntry time.Time
 	}
 	var candidates []candidate
 	for _, e := range entries {
@@ -367,32 +369,28 @@ func findLatestSessionPath(root, targetCWD string, since time.Time) (string, err
 		if info.ModTime().Before(since) {
 			continue
 		}
-		candidates = append(candidates, candidate{
-			path:    filepath.Join(root, e.Name()),
-			modTime: info.ModTime(),
-		})
+		p := filepath.Join(root, e.Name())
+		if first, ok := sessionFirstEntryTime(p, targetCWD, since); ok {
+			candidates = append(candidates, candidate{path: p, firstEntry: first})
+		}
 	}
 	if len(candidates) == 0 {
 		return "", errors.New("no session files found")
 	}
-	// Sort newest first.
+	// Sort by first entry time, newest first — the session that started
+	// most recently (closest to our startedAt) is most likely ours.
 	sort.Slice(candidates, func(i, j int) bool {
-		return candidates[i].modTime.After(candidates[j].modTime)
+		return candidates[i].firstEntry.After(candidates[j].firstEntry)
 	})
-	// Return the first file that has an entry matching our cwd.
-	for _, c := range candidates {
-		if matchesSession(c.path, targetCWD, since) {
-			return c.path, nil
-		}
-	}
-	return "", errors.New("no matching session found")
+	return candidates[0].path, nil
 }
 
-// matchesSession peeks at the first few lines of a JSONL file to verify cwd.
-func matchesSession(path, targetCWD string, since time.Time) bool {
+// sessionFirstEntryTime reads the first entry in a JSONL session file,
+// verifies it matches targetCWD and is after since, and returns its timestamp.
+func sessionFirstEntryTime(path, targetCWD string, since time.Time) (time.Time, bool) {
 	f, err := os.Open(path)
 	if err != nil {
-		return false
+		return time.Time{}, false
 	}
 	defer f.Close()
 
@@ -404,12 +402,21 @@ func matchesSession(path, targetCWD string, since time.Time) bool {
 		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
 			continue
 		}
-		if entry.CWD == "" {
-			continue
+		if entry.CWD != "" && entry.CWD != targetCWD {
+			return time.Time{}, false
 		}
-		return entry.CWD == targetCWD
+		if entry.Timestamp != "" {
+			t, err := time.Parse(time.RFC3339Nano, entry.Timestamp)
+			if err == nil && t.After(since) {
+				return t, true
+			}
+			t2, err := time.Parse(time.RFC3339, entry.Timestamp)
+			if err == nil && t2.After(since) {
+				return t2, true
+			}
+		}
 	}
-	return false
+	return time.Time{}, false
 }
 
 func tailSessionFile(ctx context.Context, path string, mirrorReasoning bool, emit func(mirrorLine)) error {

--- a/cmd/claude-relay/main.go
+++ b/cmd/claude-relay/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/conflicthq/scuttlebot/pkg/ircagent"
 	"github.com/conflicthq/scuttlebot/pkg/sessionrelay"
 	"github.com/creack/pty"
+	"github.com/google/uuid"
 	"golang.org/x/term"
 	"gopkg.in/yaml.v3"
 )
@@ -77,6 +78,7 @@ type config struct {
 	Channels           []string
 	ChannelStateFile   string
 	SessionID          string
+	ClaudeSessionID    string // UUID passed to Claude Code via --session-id
 	Nick               string
 	HooksEnabled       bool
 	InterruptOnMessage bool
@@ -188,7 +190,8 @@ func run(cfg config) error {
 	}
 
 	startedAt := time.Now()
-	cmd := exec.Command(cfg.ClaudeBin, cfg.Args...)
+	args := append(cfg.Args, "--session-id", cfg.ClaudeSessionID)
+	cmd := exec.Command(cfg.ClaudeBin, args...)
 	cmd.Env = append(os.Environ(),
 		"SCUTTLEBOT_CONFIG_FILE="+cfg.ConfigFile,
 		"SCUTTLEBOT_URL="+cfg.URL,
@@ -307,11 +310,14 @@ func mirrorSessionLoop(ctx context.Context, relay sessionrelay.Connector, cfg co
 	}
 }
 
-func discoverSessionPath(ctx context.Context, cfg config, startedAt time.Time) (string, error) {
+func discoverSessionPath(ctx context.Context, cfg config, _ time.Time) (string, error) {
 	root, err := claudeSessionsRoot(cfg.TargetCWD)
 	if err != nil {
 		return "", err
 	}
+
+	// We passed --session-id to Claude Code, so the file name is deterministic.
+	target := filepath.Join(root, cfg.ClaudeSessionID+".jsonl")
 
 	ctx, cancel := context.WithTimeout(ctx, defaultDiscoverWait)
 	defer cancel()
@@ -320,13 +326,12 @@ func discoverSessionPath(ctx context.Context, cfg config, startedAt time.Time) (
 	defer ticker.Stop()
 
 	for {
-		path, err := findLatestSessionPath(root, cfg.TargetCWD, startedAt.Add(-2*time.Second))
-		if err == nil && path != "" {
-			return path, nil
+		if _, err := os.Stat(target); err == nil {
+			return target, nil
 		}
 		select {
 		case <-ctx.Done():
-			return "", ctx.Err()
+			return "", fmt.Errorf("session file %s not found", target)
 		case <-ticker.C:
 		}
 	}
@@ -341,82 +346,6 @@ func claudeSessionsRoot(cwd string) (string, error) {
 	sanitized := strings.ReplaceAll(cwd, "/", "-")
 	sanitized = strings.TrimLeft(sanitized, "-")
 	return filepath.Join(home, ".claude", "projects", "-"+sanitized), nil
-}
-
-// findLatestSessionPath finds the .jsonl file in root whose first entry
-// timestamp is closest to (but after) since — this ensures each relay
-// latches onto its own subprocess's session rather than whichever file
-// happens to be most actively written to.
-func findLatestSessionPath(root, targetCWD string, since time.Time) (string, error) {
-	entries, err := os.ReadDir(root)
-	if err != nil {
-		return "", err
-	}
-
-	type candidate struct {
-		path       string
-		firstEntry time.Time
-	}
-	var candidates []candidate
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
-			continue
-		}
-		info, err := e.Info()
-		if err != nil {
-			continue
-		}
-		if info.ModTime().Before(since) {
-			continue
-		}
-		p := filepath.Join(root, e.Name())
-		if first, ok := sessionFirstEntryTime(p, targetCWD, since); ok {
-			candidates = append(candidates, candidate{path: p, firstEntry: first})
-		}
-	}
-	if len(candidates) == 0 {
-		return "", errors.New("no session files found")
-	}
-	// Sort by first entry time, newest first — the session that started
-	// most recently (closest to our startedAt) is most likely ours.
-	sort.Slice(candidates, func(i, j int) bool {
-		return candidates[i].firstEntry.After(candidates[j].firstEntry)
-	})
-	return candidates[0].path, nil
-}
-
-// sessionFirstEntryTime reads the first entry in a JSONL session file,
-// verifies it matches targetCWD and is after since, and returns its timestamp.
-func sessionFirstEntryTime(path, targetCWD string, since time.Time) (time.Time, bool) {
-	f, err := os.Open(path)
-	if err != nil {
-		return time.Time{}, false
-	}
-	defer f.Close()
-
-	scanner := bufio.NewScanner(f)
-	checked := 0
-	for scanner.Scan() && checked < 5 {
-		checked++
-		var entry claudeSessionEntry
-		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
-			continue
-		}
-		if entry.CWD != "" && entry.CWD != targetCWD {
-			return time.Time{}, false
-		}
-		if entry.Timestamp != "" {
-			t, err := time.Parse(time.RFC3339Nano, entry.Timestamp)
-			if err == nil && t.After(since) {
-				return t, true
-			}
-			t2, err := time.Parse(time.RFC3339, entry.Timestamp)
-			if err == nil && t2.After(since) {
-				return t2, true
-			}
-		}
-	}
-	return time.Time{}, false
 }
 
 func tailSessionFile(ctx context.Context, path string, mirrorReasoning bool, emit func(mirrorLine)) error {
@@ -1022,6 +951,7 @@ func loadConfig(args []string) (config, error) {
 		sessionID = defaultSessionID(target)
 	}
 	cfg.SessionID = sanitize(sessionID)
+	cfg.ClaudeSessionID = uuid.New().String()
 
 	nick := getenvOr(fileConfig, "SCUTTLEBOT_NICK", "")
 	if nick == "" {

--- a/cmd/claude-relay/main.go
+++ b/cmd/claude-relay/main.go
@@ -404,6 +404,10 @@ func tailSessionFile(ctx context.Context, path string, mirrorReasoning bool, emi
 				return nil
 			case <-time.After(defaultScanInterval):
 			}
+			// Reset the buffered reader so it retries the underlying
+			// file descriptor. bufio.Reader caches EOF and won't see
+			// new bytes appended to the file without a reset.
+			reader.Reset(file)
 			continue
 		}
 		return err

--- a/cmd/claude-relay/main.go
+++ b/cmd/claude-relay/main.go
@@ -89,6 +89,12 @@ type config struct {
 
 type message = sessionrelay.Message
 
+// mirrorLine is a single line of relay output with optional structured metadata.
+type mirrorLine struct {
+	Text string
+	Meta json.RawMessage // nil for plain text lines
+}
+
 type relayState struct {
 	mu       sync.RWMutex
 	lastBusy time.Time
@@ -281,12 +287,16 @@ func mirrorSessionLoop(ctx context.Context, relay sessionrelay.Connector, cfg co
 			time.Sleep(10 * time.Second)
 			continue
 		}
-		if err := tailSessionFile(ctx, sessionPath, cfg.MirrorReasoning, func(text string) {
-			for _, line := range splitMirrorText(text) {
+		if err := tailSessionFile(ctx, sessionPath, cfg.MirrorReasoning, func(ml mirrorLine) {
+			for _, line := range splitMirrorText(ml.Text) {
 				if line == "" {
 					continue
 				}
-				_ = relay.Post(ctx, line)
+				if len(ml.Meta) > 0 {
+					_ = relay.PostWithMeta(ctx, line, ml.Meta)
+				} else {
+					_ = relay.Post(ctx, line)
+				}
 			}
 		}); err != nil && ctx.Err() == nil {
 			// Tail lost — retry discovery.
@@ -402,7 +412,7 @@ func matchesSession(path, targetCWD string, since time.Time) bool {
 	return false
 }
 
-func tailSessionFile(ctx context.Context, path string, mirrorReasoning bool, emit func(string)) error {
+func tailSessionFile(ctx context.Context, path string, mirrorReasoning bool, emit func(mirrorLine)) error {
 	file, err := os.Open(path)
 	if err != nil {
 		return err
@@ -417,9 +427,9 @@ func tailSessionFile(ctx context.Context, path string, mirrorReasoning bool, emi
 	for {
 		line, err := reader.ReadBytes('\n')
 		if len(line) > 0 {
-			for _, text := range sessionMessages(line, mirrorReasoning) {
-				if text != "" {
-					emit(text)
+			for _, ml := range sessionMessages(line, mirrorReasoning) {
+				if ml.Text != "" {
+					emit(ml)
 				}
 			}
 		}
@@ -438,9 +448,10 @@ func tailSessionFile(ctx context.Context, path string, mirrorReasoning bool, emi
 	}
 }
 
-// sessionMessages parses a Claude Code JSONL line and returns IRC-ready strings.
+// sessionMessages parses a Claude Code JSONL line and returns mirror lines
+// with optional structured metadata for rich rendering in the web UI.
 // If mirrorReasoning is true, thinking blocks are included prefixed with "💭 ".
-func sessionMessages(line []byte, mirrorReasoning bool) []string {
+func sessionMessages(line []byte, mirrorReasoning bool) []mirrorLine {
 	var entry claudeSessionEntry
 	if err := json.Unmarshal(line, &entry); err != nil {
 		return nil
@@ -449,30 +460,87 @@ func sessionMessages(line []byte, mirrorReasoning bool) []string {
 		return nil
 	}
 
-	var out []string
+	var out []mirrorLine
 	for _, block := range entry.Message.Content {
 		switch block.Type {
 		case "text":
 			for _, l := range splitMirrorText(block.Text) {
 				if l != "" {
-					out = append(out, sanitizeSecrets(l))
+					out = append(out, mirrorLine{Text: sanitizeSecrets(l)})
 				}
 			}
 		case "tool_use":
 			if msg := summarizeToolUse(block.Name, block.Input); msg != "" {
-				out = append(out, msg)
+				out = append(out, mirrorLine{
+					Text: msg,
+					Meta: toolMeta(block.Name, block.Input),
+				})
 			}
 		case "thinking":
 			if mirrorReasoning {
 				for _, l := range splitMirrorText(block.Text) {
 					if l != "" {
-						out = append(out, "💭 "+sanitizeSecrets(l))
+						out = append(out, mirrorLine{Text: "💭 " + sanitizeSecrets(l)})
 					}
 				}
 			}
 		}
 	}
 	return out
+}
+
+// toolMeta builds a JSON metadata envelope for a tool_use block.
+func toolMeta(name string, inputRaw json.RawMessage) json.RawMessage {
+	var input map[string]json.RawMessage
+	_ = json.Unmarshal(inputRaw, &input)
+
+	data := map[string]string{"tool": name}
+
+	str := func(key string) string {
+		v, ok := input[key]
+		if !ok {
+			return ""
+		}
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return strings.Trim(string(v), `"`)
+		}
+		return s
+	}
+
+	switch name {
+	case "Bash":
+		if cmd := str("command"); cmd != "" {
+			data["command"] = sanitizeSecrets(cmd)
+		}
+	case "Edit", "Write", "Read":
+		if p := str("file_path"); p != "" {
+			data["file"] = p
+		}
+	case "Glob":
+		if p := str("pattern"); p != "" {
+			data["pattern"] = p
+		}
+	case "Grep":
+		if p := str("pattern"); p != "" {
+			data["pattern"] = p
+		}
+	case "WebFetch":
+		if u := str("url"); u != "" {
+			data["url"] = sanitizeSecrets(u)
+		}
+	case "WebSearch":
+		if q := str("query"); q != "" {
+			data["query"] = q
+		}
+	}
+
+	meta := map[string]any{
+		"type": "tool_result",
+		"data": data,
+	}
+	b, _ := json.Marshal(meta)
+	return b
 }
 
 func summarizeToolUse(name string, inputRaw json.RawMessage) string {

--- a/cmd/claude-relay/main.go
+++ b/cmd/claude-relay/main.go
@@ -190,7 +190,10 @@ func run(cfg config) error {
 	}
 
 	startedAt := time.Now()
-	args := append(cfg.Args, "--session-id", cfg.ClaudeSessionID)
+	args := make([]string, 0, len(cfg.Args)+2)
+	args = append(args, "--session-id", cfg.ClaudeSessionID)
+	args = append(args, cfg.Args...)
+	fmt.Fprintf(os.Stderr, "claude-relay: session-id %s\n", cfg.ClaudeSessionID)
 	cmd := exec.Command(cfg.ClaudeBin, args...)
 	cmd.Env = append(os.Environ(),
 		"SCUTTLEBOT_CONFIG_FILE="+cfg.ConfigFile,
@@ -318,6 +321,7 @@ func discoverSessionPath(ctx context.Context, cfg config, _ time.Time) (string, 
 
 	// We passed --session-id to Claude Code, so the file name is deterministic.
 	target := filepath.Join(root, cfg.ClaudeSessionID+".jsonl")
+	fmt.Fprintf(os.Stderr, "claude-relay: waiting for session file %s\n", target)
 
 	ctx, cancel := context.WithTimeout(ctx, defaultDiscoverWait)
 	defer cancel()
@@ -327,11 +331,12 @@ func discoverSessionPath(ctx context.Context, cfg config, _ time.Time) (string, 
 
 	for {
 		if _, err := os.Stat(target); err == nil {
+			fmt.Fprintf(os.Stderr, "claude-relay: found session file %s\n", target)
 			return target, nil
 		}
 		select {
 		case <-ctx.Done():
-			return "", fmt.Errorf("session file %s not found", target)
+			return "", fmt.Errorf("session file %s not found after %v", target, defaultDiscoverWait)
 		case <-ticker.C:
 		}
 	}

--- a/cmd/claude-relay/main.go
+++ b/cmd/claude-relay/main.go
@@ -190,11 +190,17 @@ func run(cfg config) error {
 	}
 
 	startedAt := time.Now()
-	args := make([]string, 0, len(cfg.Args)+2)
-	args = append(args, "--session-id", cfg.ClaudeSessionID)
-	args = append(args, cfg.Args...)
-	fmt.Fprintf(os.Stderr, "claude-relay: session-id %s\n", cfg.ClaudeSessionID)
-	cmd := exec.Command(cfg.ClaudeBin, args...)
+	// If resuming, extract the session ID from --resume arg. Otherwise use
+	// our generated UUID via --session-id for new sessions.
+	if resumeID := extractResumeID(cfg.Args); resumeID != "" {
+		cfg.ClaudeSessionID = resumeID
+		fmt.Fprintf(os.Stderr, "claude-relay: resuming session %s\n", resumeID)
+	} else {
+		// New session — inject --session-id so the file name is deterministic.
+		cfg.Args = append([]string{"--session-id", cfg.ClaudeSessionID}, cfg.Args...)
+		fmt.Fprintf(os.Stderr, "claude-relay: new session %s\n", cfg.ClaudeSessionID)
+	}
+	cmd := exec.Command(cfg.ClaudeBin, cfg.Args...)
 	cmd.Env = append(os.Environ(),
 		"SCUTTLEBOT_CONFIG_FILE="+cfg.ConfigFile,
 		"SCUTTLEBOT_URL="+cfg.URL,
@@ -340,6 +346,21 @@ func discoverSessionPath(ctx context.Context, cfg config, _ time.Time) (string, 
 		case <-ticker.C:
 		}
 	}
+}
+
+// extractResumeID finds --resume or -r in args and returns the session UUID
+// that follows it. Returns "" if not resuming or if the value isn't a UUID.
+func extractResumeID(args []string) string {
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == "--resume" || args[i] == "-r" || args[i] == "--continue" {
+			val := args[i+1]
+			// Must look like a UUID (contains dashes, right length)
+			if len(val) >= 32 && strings.Contains(val, "-") {
+				return val
+			}
+		}
+	}
+	return ""
 }
 
 // claudeSessionsRoot returns ~/.claude/projects/<sanitized-cwd>/

--- a/cmd/claude-relay/main_test.go
+++ b/cmd/claude-relay/main_test.go
@@ -56,13 +56,13 @@ func TestSessionMessagesThinking(t *testing.T) {
 
 	// thinking off — only text
 	got := sessionMessages(line, false)
-	if len(got) != 1 || got[0] != "final answer" {
+	if len(got) != 1 || got[0].Text != "final answer" {
 		t.Fatalf("mirrorReasoning=false: got %#v", got)
 	}
 
 	// thinking on — both, thinking prefixed
 	got = sessionMessages(line, true)
-	if len(got) != 2 || got[0] != "💭 reasoning here" || got[1] != "final answer" {
+	if len(got) != 2 || got[0].Text != "💭 reasoning here" || got[1].Text != "final answer" {
 		t.Fatalf("mirrorReasoning=true: got %#v", got)
 	}
 }

--- a/cmd/claude-relay/main_test.go
+++ b/cmd/claude-relay/main_test.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"context"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 func TestFilterMessages(t *testing.T) {
@@ -48,6 +52,148 @@ func TestLoadConfig(t *testing.T) {
 	}
 	if cfg.Nick != "claude-scuttlebot-abc" {
 		t.Errorf("expected nick claude-scuttlebot-abc, got %s", cfg.Nick)
+	}
+}
+
+func TestClaudeSessionIDGenerated(t *testing.T) {
+	t.Setenv("SCUTTLEBOT_CONFIG_FILE", filepath.Join(t.TempDir(), "scuttlebot-relay.env"))
+	t.Setenv("SCUTTLEBOT_URL", "http://test:8080")
+	t.Setenv("SCUTTLEBOT_TOKEN", "test-token")
+
+	cfg, err := loadConfig([]string{"--cd", "../.."})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// ClaudeSessionID must be a valid UUID
+	if cfg.ClaudeSessionID == "" {
+		t.Fatal("ClaudeSessionID is empty")
+	}
+	if _, err := uuid.Parse(cfg.ClaudeSessionID); err != nil {
+		t.Fatalf("ClaudeSessionID is not a valid UUID: %s", cfg.ClaudeSessionID)
+	}
+}
+
+func TestClaudeSessionIDUnique(t *testing.T) {
+	t.Setenv("SCUTTLEBOT_CONFIG_FILE", filepath.Join(t.TempDir(), "scuttlebot-relay.env"))
+	t.Setenv("SCUTTLEBOT_URL", "http://test:8080")
+	t.Setenv("SCUTTLEBOT_TOKEN", "test-token")
+
+	cfg1, err := loadConfig([]string{"--cd", "../.."})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg2, err := loadConfig([]string{"--cd", "../.."})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg1.ClaudeSessionID == cfg2.ClaudeSessionID {
+		t.Fatal("two loadConfig calls produced the same ClaudeSessionID")
+	}
+}
+
+func TestSessionIDArgsPrepended(t *testing.T) {
+	// Simulate what run() does with args
+	userArgs := []string{"--dangerously-skip-permissions", "--chrome"}
+	sessionID := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+	args := make([]string, 0, len(userArgs)+2)
+	args = append(args, "--session-id", sessionID)
+	args = append(args, userArgs...)
+
+	if len(args) != 4 {
+		t.Fatalf("expected 4 args, got %d", len(args))
+	}
+	if args[0] != "--session-id" {
+		t.Errorf("args[0] = %q, want --session-id", args[0])
+	}
+	if args[1] != sessionID {
+		t.Errorf("args[1] = %q, want %s", args[1], sessionID)
+	}
+	if args[2] != "--dangerously-skip-permissions" {
+		t.Errorf("args[2] = %q, want --dangerously-skip-permissions", args[2])
+	}
+	// Verify original slice not mutated
+	if len(userArgs) != 2 {
+		t.Errorf("userArgs mutated: len=%d", len(userArgs))
+	}
+}
+
+func TestDiscoverSessionPathFindsFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	sessionID := uuid.New().String()
+
+	// Create a fake session file
+	sessionFile := filepath.Join(tmpDir, sessionID+".jsonl")
+	if err := os.WriteFile(sessionFile, []byte(`{"sessionId":"`+sessionID+`"}`+"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := config{
+		ClaudeSessionID: sessionID,
+		TargetCWD:       "/fake/path",
+	}
+
+	// Override claudeSessionsRoot by pointing TargetCWD at something that
+	// produces the tmpDir. Since claudeSessionsRoot uses $HOME, we need
+	// to test discoverSessionPath's file-finding logic directly.
+	target := filepath.Join(tmpDir, sessionID+".jsonl")
+	if _, err := os.Stat(target); err != nil {
+		t.Fatalf("session file should exist: %v", err)
+	}
+
+	// Test the core logic: Stat finds the file
+	_ = cfg // cfg is valid
+}
+
+func TestDiscoverSessionPathTimeout(t *testing.T) {
+	cfg := config{
+		ClaudeSessionID: uuid.New().String(),
+		TargetCWD:       t.TempDir(), // empty dir, no session file
+	}
+
+	// Use a very short timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	_, err := discoverSessionPath(ctx, cfg, time.Now())
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+}
+
+func TestDiscoverSessionPathWaitsForFile(t *testing.T) {
+	sessionID := uuid.New().String()
+	cfg := config{
+		ClaudeSessionID: sessionID,
+		TargetCWD:       t.TempDir(),
+	}
+
+	// Create the file after a delay (simulates Claude Code starting up)
+	root, err := claudeSessionsRoot(cfg.TargetCWD)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(root, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		target := filepath.Join(root, sessionID+".jsonl")
+		_ = os.WriteFile(target, []byte(`{"sessionId":"`+sessionID+`"}`+"\n"), 0600)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	path, err := discoverSessionPath(ctx, cfg, time.Now())
+	if err != nil {
+		t.Fatalf("expected to find file, got error: %v", err)
+	}
+	if filepath.Base(path) != sessionID+".jsonl" {
+		t.Errorf("found wrong file: %s", path)
 	}
 }
 

--- a/cmd/claude-relay/main_test.go
+++ b/cmd/claude-relay/main_test.go
@@ -120,6 +120,31 @@ func TestSessionIDArgsPrepended(t *testing.T) {
 	}
 }
 
+func TestExtractResumeID(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"no resume", []string{"--dangerously-skip-permissions"}, ""},
+		{"--resume with UUID", []string{"--resume", "740fab38-b4c7-4dfc-a82a-2fe24b48baab"}, "740fab38-b4c7-4dfc-a82a-2fe24b48baab"},
+		{"-r with UUID", []string{"-r", "29f0a0bf-b2e8-4eee-bfd8-aabbd90b41fb"}, "29f0a0bf-b2e8-4eee-bfd8-aabbd90b41fb"},
+		{"--continue with UUID", []string{"--continue", "21b39df2-c032-4fb4-be1c-0b607a9ee702"}, "21b39df2-c032-4fb4-be1c-0b607a9ee702"},
+		{"--resume without value", []string{"--resume"}, ""},
+		{"--resume with non-UUID", []string{"--resume", "latest"}, ""},
+		{"--resume with short string", []string{"--resume", "abc"}, ""},
+		{"mixed args", []string{"--dangerously-skip-permissions", "--resume", "740fab38-b4c7-4dfc-a82a-2fe24b48baab", "--chrome"}, "740fab38-b4c7-4dfc-a82a-2fe24b48baab"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractResumeID(tt.args)
+			if got != tt.want {
+				t.Errorf("extractResumeID(%v) = %q, want %q", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDiscoverSessionPathFindsFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	sessionID := uuid.New().String()

--- a/cmd/codex-relay/main.go
+++ b/cmd/codex-relay/main.go
@@ -1137,11 +1137,16 @@ func findSessionPathByThreadID(root, threadID string) (string, error) {
 	return match, nil
 }
 
+// findLatestSessionPath finds the .jsonl file in root whose first entry
+// timestamp is closest to (but after) notBefore — this ensures each relay
+// latches onto its own subprocess's session rather than whichever session
+// happens to have the latest timestamp when multiple sessions share a CWD.
 func findLatestSessionPath(root, target string, notBefore time.Time) (string, error) {
-	var (
-		bestPath string
-		bestTime time.Time
-	)
+	type candidate struct {
+		path string
+		ts   time.Time
+	}
+	var candidates []candidate
 
 	err := filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
 		if walkErr != nil || d.IsDir() || !strings.HasSuffix(path, ".jsonl") {
@@ -1157,19 +1162,21 @@ func findLatestSessionPath(root, target string, notBefore time.Time) (string, er
 		if ts.Before(notBefore) {
 			return nil
 		}
-		if bestPath == "" || ts.After(bestTime) {
-			bestPath = path
-			bestTime = ts
-		}
+		candidates = append(candidates, candidate{path: path, ts: ts})
 		return nil
 	})
 	if err != nil {
 		return "", err
 	}
-	if bestPath == "" {
+	if len(candidates) == 0 {
 		return "", os.ErrNotExist
 	}
-	return bestPath, nil
+	// Sort newest first — the session that started most recently
+	// (closest to our relay's startedAt) is most likely ours.
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].ts.After(candidates[j].ts)
+	})
+	return candidates[0].path, nil
 }
 
 func readSessionMeta(path string) (sessionMetaPayload, time.Time, error) {

--- a/cmd/codex-relay/main.go
+++ b/cmd/codex-relay/main.go
@@ -1138,9 +1138,8 @@ func findSessionPathByThreadID(root, threadID string) (string, error) {
 }
 
 // findLatestSessionPath finds the .jsonl file in root whose first entry
-// timestamp is closest to (but after) notBefore — this ensures each relay
-// latches onto its own subprocess's session rather than whichever session
-// happens to have the latest timestamp when multiple sessions share a CWD.
+// timestamp is closest to notBefore — this ensures each relay latches onto
+// its own subprocess's session when multiple sessions share a CWD.
 func findLatestSessionPath(root, target string, notBefore time.Time) (string, error) {
 	type candidate struct {
 		path string
@@ -1171,12 +1170,25 @@ func findLatestSessionPath(root, target string, notBefore time.Time) (string, er
 	if len(candidates) == 0 {
 		return "", os.ErrNotExist
 	}
-	// Sort newest first — the session that started most recently
-	// (closest to our relay's startedAt) is most likely ours.
-	sort.Slice(candidates, func(i, j int) bool {
-		return candidates[i].ts.After(candidates[j].ts)
-	})
-	return candidates[0].path, nil
+	// Pick the session whose start time is closest to notBefore.
+	// When multiple relays start near-simultaneously, each relay's
+	// notBefore is slightly different, so each matches its own session.
+	best := 0
+	bestDelta := candidates[0].ts.Sub(notBefore)
+	for i := 1; i < len(candidates); i++ {
+		delta := candidates[i].ts.Sub(notBefore)
+		if delta < 0 {
+			delta = -delta
+		}
+		if bestDelta < 0 {
+			bestDelta = -bestDelta
+		}
+		if delta < bestDelta {
+			best = i
+			bestDelta = candidates[i].ts.Sub(notBefore)
+		}
+	}
+	return candidates[best].path, nil
 }
 
 func readSessionMeta(path string) (sessionMetaPayload, time.Time, error) {

--- a/cmd/codex-relay/main.go
+++ b/cmd/codex-relay/main.go
@@ -89,6 +89,12 @@ type config struct {
 
 type message = sessionrelay.Message
 
+// mirrorLine is a single line of relay output with optional structured metadata.
+type mirrorLine struct {
+	Text string
+	Meta json.RawMessage
+}
+
 type relayState struct {
 	mu       sync.RWMutex
 	lastBusy time.Time
@@ -811,12 +817,16 @@ func mirrorSessionLoop(ctx context.Context, relay sessionrelay.Connector, cfg co
 			time.Sleep(10 * time.Second)
 			continue
 		}
-		if err := tailSessionFile(ctx, sessionPath, cfg.MirrorReasoning, func(text string) {
-			for _, line := range splitMirrorText(text) {
+		if err := tailSessionFile(ctx, sessionPath, cfg.MirrorReasoning, func(ml mirrorLine) {
+			for _, line := range splitMirrorText(ml.Text) {
 				if line == "" {
 					continue
 				}
-				_ = relay.Post(ctx, line)
+				if len(ml.Meta) > 0 {
+					_ = relay.PostWithMeta(ctx, line, ml.Meta)
+				} else {
+					_ = relay.Post(ctx, line)
+				}
 			}
 		}); err != nil && ctx.Err() == nil {
 			time.Sleep(5 * time.Second)
@@ -864,7 +874,7 @@ func waitForSessionPath(ctx context.Context, find func() (string, error)) (strin
 	}
 }
 
-func tailSessionFile(ctx context.Context, path string, mirrorReasoning bool, emit func(string)) error {
+func tailSessionFile(ctx context.Context, path string, mirrorReasoning bool, emit func(mirrorLine)) error {
 	file, err := os.Open(path)
 	if err != nil {
 		return err
@@ -879,9 +889,9 @@ func tailSessionFile(ctx context.Context, path string, mirrorReasoning bool, emi
 	for {
 		line, err := reader.ReadBytes('\n')
 		if len(line) > 0 {
-			for _, text := range sessionMessages(line, mirrorReasoning) {
-				if text != "" {
-					emit(text)
+			for _, ml := range sessionMessages(line, mirrorReasoning) {
+				if ml.Text != "" {
+					emit(ml)
 				}
 			}
 		}
@@ -900,7 +910,7 @@ func tailSessionFile(ctx context.Context, path string, mirrorReasoning bool, emi
 	}
 }
 
-func sessionMessages(line []byte, mirrorReasoning bool) []string {
+func sessionMessages(line []byte, mirrorReasoning bool) []mirrorLine {
 	var env sessionEnvelope
 	if err := json.Unmarshal(line, &env); err != nil {
 		return nil
@@ -917,11 +927,13 @@ func sessionMessages(line []byte, mirrorReasoning bool) []string {
 	switch payload.Type {
 	case "function_call":
 		if msg := summarizeFunctionCall(payload.Name, payload.Arguments); msg != "" {
-			return []string{msg}
+			meta := codexToolMeta(payload.Name, payload.Arguments)
+			return []mirrorLine{{Text: msg, Meta: meta}}
 		}
 	case "custom_tool_call":
 		if msg := summarizeCustomToolCall(payload.Name, payload.Input); msg != "" {
-			return []string{msg}
+			meta := codexToolMeta(payload.Name, payload.Input)
+			return []mirrorLine{{Text: msg, Meta: meta}}
 		}
 	case "message":
 		if payload.Role != "assistant" {
@@ -930,6 +942,26 @@ func sessionMessages(line []byte, mirrorReasoning bool) []string {
 		return flattenAssistantContent(payload.Content, mirrorReasoning)
 	}
 	return nil
+}
+
+// codexToolMeta builds a JSON metadata envelope for a Codex tool call.
+func codexToolMeta(name, argsJSON string) json.RawMessage {
+	data := map[string]string{"tool": name}
+	switch name {
+	case "exec_command":
+		var args execCommandArgs
+		if err := json.Unmarshal([]byte(argsJSON), &args); err == nil && args.Cmd != "" {
+			data["command"] = sanitizeSecrets(args.Cmd)
+		}
+	case "apply_patch":
+		files := patchTargets(argsJSON)
+		if len(files) > 0 {
+			data["file"] = files[0]
+		}
+	}
+	meta := map[string]any{"type": "tool_result", "data": data}
+	b, _ := json.Marshal(meta)
+	return b
 }
 
 func summarizeFunctionCall(name, argsJSON string) string {
@@ -977,21 +1009,21 @@ func summarizeCustomToolCall(name, input string) string {
 	}
 }
 
-func flattenAssistantContent(content []sessionContent, mirrorReasoning bool) []string {
-	var lines []string
+func flattenAssistantContent(content []sessionContent, mirrorReasoning bool) []mirrorLine {
+	var lines []mirrorLine
 	for _, item := range content {
 		switch item.Type {
 		case "output_text":
 			for _, line := range splitMirrorText(item.Text) {
 				if line != "" {
-					lines = append(lines, line)
+					lines = append(lines, mirrorLine{Text: line})
 				}
 			}
 		case "reasoning":
 			if mirrorReasoning {
 				for _, line := range splitMirrorText(item.Text) {
 					if line != "" {
-						lines = append(lines, "💭 "+line)
+						lines = append(lines, mirrorLine{Text: "💭 " + line})
 					}
 				}
 			}

--- a/cmd/codex-relay/main.go
+++ b/cmd/codex-relay/main.go
@@ -209,6 +209,13 @@ func run(cfg config) error {
 	}
 
 	cmd := exec.Command(cfg.CodexBin, cfg.Args...)
+	// Snapshot existing session files before starting the subprocess so
+	// discovery can distinguish our session from pre-existing ones.
+	var preExisting map[string]struct{}
+	if sessRoot, err := codexSessionsRoot(); err == nil {
+		preExisting = snapshotSessionFiles(sessRoot)
+	}
+
 	startedAt := time.Now()
 	cmd.Env = append(os.Environ(),
 		"SCUTTLEBOT_CONFIG_FILE="+cfg.ConfigFile,
@@ -223,7 +230,7 @@ func run(cfg config) error {
 		"SCUTTLEBOT_ACTIVITY_VIA_BROKER="+boolString(relayActive),
 	)
 	if relayActive {
-		go mirrorSessionLoop(ctx, relay, cfg, startedAt)
+		go mirrorSessionLoop(ctx, relay, cfg, startedAt, preExisting)
 		go presenceLoopPtr(ctx, &relay, cfg.HeartbeatInterval)
 	}
 
@@ -403,7 +410,7 @@ func handleReconnectSignal(ctx context.Context, relayPtr *sessionrelay.Connector
 			// Restart mirror and input loops with the new connector.
 			// Use epoch time for mirror so it finds the existing session file
 			// regardless of when it was last modified.
-			go mirrorSessionLoop(ctx, conn, cfg, time.Time{})
+			go mirrorSessionLoop(ctx, conn, cfg, time.Time{}, nil)
 			go relayInputLoop(ctx, conn, cfg, state, ptmx, now)
 			break
 		}
@@ -804,12 +811,12 @@ func defaultSessionID(target string) string {
 	return fmt.Sprintf("%08x", sum)
 }
 
-func mirrorSessionLoop(ctx context.Context, relay sessionrelay.Connector, cfg config, startedAt time.Time) {
+func mirrorSessionLoop(ctx context.Context, relay sessionrelay.Connector, cfg config, startedAt time.Time, preExisting map[string]struct{}) {
 	for {
 		if ctx.Err() != nil {
 			return
 		}
-		sessionPath, err := discoverSessionPath(ctx, cfg, startedAt)
+		sessionPath, err := discoverSessionPath(ctx, cfg, startedAt, preExisting)
 		if err != nil {
 			if ctx.Err() != nil {
 				return
@@ -836,7 +843,7 @@ func mirrorSessionLoop(ctx context.Context, relay sessionrelay.Connector, cfg co
 	}
 }
 
-func discoverSessionPath(ctx context.Context, cfg config, startedAt time.Time) (string, error) {
+func discoverSessionPath(ctx context.Context, cfg config, startedAt time.Time, preExisting map[string]struct{}) (string, error) {
 	root, err := codexSessionsRoot()
 	if err != nil {
 		return "", err
@@ -850,7 +857,7 @@ func discoverSessionPath(ctx context.Context, cfg config, startedAt time.Time) (
 
 	target := filepath.Clean(cfg.TargetCWD)
 	return waitForSessionPath(ctx, func() (string, error) {
-		return findLatestSessionPath(root, target, startedAt.Add(-2*time.Second))
+		return findLatestSessionPath(root, target, startedAt.Add(-2*time.Second), preExisting)
 	})
 }
 
@@ -1105,6 +1112,21 @@ func explicitThreadID(args []string) string {
 	return ""
 }
 
+// snapshotSessionFiles returns the set of .jsonl file paths currently under root.
+// Called before starting the Codex subprocess so discovery can skip pre-existing
+// sessions and deterministically find the one our subprocess creates.
+func snapshotSessionFiles(root string) map[string]struct{} {
+	existing := make(map[string]struct{})
+	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".jsonl") {
+			return nil
+		}
+		existing[path] = struct{}{}
+		return nil
+	})
+	return existing
+}
+
 func codexSessionsRoot() (string, error) {
 	if value := os.Getenv("CODEX_HOME"); value != "" {
 		return filepath.Join(value, "sessions"), nil
@@ -1137,10 +1159,12 @@ func findSessionPathByThreadID(root, threadID string) (string, error) {
 	return match, nil
 }
 
-// findLatestSessionPath finds the .jsonl file in root whose first entry
-// timestamp is closest to notBefore — this ensures each relay latches onto
-// its own subprocess's session when multiple sessions share a CWD.
-func findLatestSessionPath(root, target string, notBefore time.Time) (string, error) {
+// findLatestSessionPath finds the .jsonl file in root that was created by our
+// subprocess. It uses a pre-existing file snapshot to skip sessions that
+// existed before the subprocess started, then filters by CWD and picks the
+// oldest new match. When preExisting is nil (reconnect), it falls back to
+// accepting any file whose timestamp is >= notBefore.
+func findLatestSessionPath(root, target string, notBefore time.Time, preExisting map[string]struct{}) (string, error) {
 	type candidate struct {
 		path string
 		ts   time.Time
@@ -1150,6 +1174,11 @@ func findLatestSessionPath(root, target string, notBefore time.Time) (string, er
 	err := filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
 		if walkErr != nil || d.IsDir() || !strings.HasSuffix(path, ".jsonl") {
 			return nil
+		}
+		if preExisting != nil {
+			if _, existed := preExisting[path]; existed {
+				return nil
+			}
 		}
 		meta, ts, err := readSessionMeta(path)
 		if err != nil {
@@ -1170,25 +1199,12 @@ func findLatestSessionPath(root, target string, notBefore time.Time) (string, er
 	if len(candidates) == 0 {
 		return "", os.ErrNotExist
 	}
-	// Pick the session whose start time is closest to notBefore.
-	// When multiple relays start near-simultaneously, each relay's
-	// notBefore is slightly different, so each matches its own session.
-	best := 0
-	bestDelta := candidates[0].ts.Sub(notBefore)
-	for i := 1; i < len(candidates); i++ {
-		delta := candidates[i].ts.Sub(notBefore)
-		if delta < 0 {
-			delta = -delta
-		}
-		if bestDelta < 0 {
-			bestDelta = -bestDelta
-		}
-		if delta < bestDelta {
-			best = i
-			bestDelta = candidates[i].ts.Sub(notBefore)
-		}
-	}
-	return candidates[best].path, nil
+	// Pick the oldest new session — the first file created after our
+	// subprocess started is most likely ours.
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].ts.Before(candidates[j].ts)
+	})
+	return candidates[0].path, nil
 }
 
 func readSessionMeta(path string) (sessionMetaPayload, time.Time, error) {

--- a/cmd/codex-relay/main_test.go
+++ b/cmd/codex-relay/main_test.go
@@ -157,13 +157,13 @@ func TestSessionMessagesFunctionCallAndAssistant(t *testing.T) {
 
 	fnLine := []byte(`{"type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{\"cmd\":\"pwd\"}"}}`)
 	got := sessionMessages(fnLine, false)
-	if len(got) != 1 || got[0] != "› pwd" {
+	if len(got) != 1 || got[0].Text != "› pwd" {
 		t.Fatalf("sessionMessages function_call = %#v", got)
 	}
 
 	msgLine := []byte(`{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"one line\nsecond line"}]}}`)
 	got = sessionMessages(msgLine, false)
-	if len(got) != 2 || got[0] != "one line" || got[1] != "second line" {
+	if len(got) != 2 || got[0].Text != "one line" || got[1].Text != "second line" {
 		t.Fatalf("sessionMessages assistant = %#v", got)
 	}
 }
@@ -173,13 +173,13 @@ func TestSessionMessagesReasoning(t *testing.T) {
 
 	// reasoning off — only output_text
 	got := sessionMessages(line, false)
-	if len(got) != 1 || got[0] != "done" {
+	if len(got) != 1 || got[0].Text != "done" {
 		t.Fatalf("mirrorReasoning=false: got %#v", got)
 	}
 
 	// reasoning on — both, reasoning prefixed
 	got = sessionMessages(line, true)
-	if len(got) != 2 || got[0] != "💭 thinking hard" || got[1] != "done" {
+	if len(got) != 2 || got[0].Text != "💭 thinking hard" || got[1].Text != "done" {
 		t.Fatalf("mirrorReasoning=true: got %#v", got)
 	}
 }

--- a/cmd/codex-relay/main_test.go
+++ b/cmd/codex-relay/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -191,5 +193,120 @@ func TestExplicitThreadID(t *testing.T) {
 	want := "019d45e1-8328-7261-9a02-5c4304e07724"
 	if got != want {
 		t.Fatalf("explicitThreadID = %q, want %q", got, want)
+	}
+}
+
+func writeSessionFile(t *testing.T, dir, uuid, cwd, timestamp string) string {
+	t.Helper()
+	content := fmt.Sprintf(`{"type":"session_meta","payload":{"id":"%s","timestamp":"%s","cwd":"%s"}}`, uuid, timestamp, cwd)
+	name := fmt.Sprintf("rollout-%s-%s.jsonl", strings.ReplaceAll(timestamp[:19], ":", "-"), uuid)
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestFindLatestSessionPathSkipsPreExisting(t *testing.T) {
+	t.Helper()
+
+	root := t.TempDir()
+	dateDir := filepath.Join(root, "2026", "04", "04")
+	if err := os.MkdirAll(dateDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cwd := "/home/user/project"
+
+	// Create a pre-existing session file.
+	oldPath := writeSessionFile(t, dateDir,
+		"aaaa-aaaa-aaaa-aaaa", cwd, "2026-04-04T10:00:00Z")
+
+	// Snapshot includes the old file.
+	preExisting := map[string]struct{}{oldPath: {}}
+
+	// Create a new session file (not in snapshot).
+	newPath := writeSessionFile(t, dateDir,
+		"bbbb-bbbb-bbbb-bbbb", cwd, "2026-04-04T10:00:01Z")
+
+	notBefore, _ := time.Parse(time.RFC3339, "2026-04-04T09:59:58Z")
+	got, err := findLatestSessionPath(root, cwd, notBefore, preExisting)
+	if err != nil {
+		t.Fatalf("findLatestSessionPath error: %v", err)
+	}
+	if got != newPath {
+		t.Fatalf("findLatestSessionPath = %q, want %q", got, newPath)
+	}
+}
+
+func TestFindLatestSessionPathPicksOldestNew(t *testing.T) {
+	t.Helper()
+
+	root := t.TempDir()
+	dateDir := filepath.Join(root, "2026", "04", "04")
+	if err := os.MkdirAll(dateDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cwd := "/home/user/project"
+
+	// Two new sessions in the same CWD, no pre-existing.
+	earlyPath := writeSessionFile(t, dateDir,
+		"cccc-cccc-cccc-cccc", cwd, "2026-04-04T10:00:01Z")
+	_ = writeSessionFile(t, dateDir,
+		"dddd-dddd-dddd-dddd", cwd, "2026-04-04T10:00:02Z")
+
+	notBefore, _ := time.Parse(time.RFC3339, "2026-04-04T10:00:00Z")
+	got, err := findLatestSessionPath(root, cwd, notBefore, map[string]struct{}{})
+	if err != nil {
+		t.Fatalf("findLatestSessionPath error: %v", err)
+	}
+	if got != earlyPath {
+		t.Fatalf("findLatestSessionPath = %q, want oldest %q", got, earlyPath)
+	}
+}
+
+func TestFindLatestSessionPathNilPreExistingAllowsAll(t *testing.T) {
+	t.Helper()
+
+	root := t.TempDir()
+	dateDir := filepath.Join(root, "2026", "04", "04")
+	if err := os.MkdirAll(dateDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cwd := "/home/user/project"
+
+	// Single file — nil preExisting (reconnect path) should find it.
+	path := writeSessionFile(t, dateDir,
+		"eeee-eeee-eeee-eeee", cwd, "2026-04-04T10:00:00Z")
+
+	got, err := findLatestSessionPath(root, cwd, time.Time{}, nil)
+	if err != nil {
+		t.Fatalf("findLatestSessionPath error: %v", err)
+	}
+	if got != path {
+		t.Fatalf("findLatestSessionPath = %q, want %q", got, path)
+	}
+}
+
+func TestSnapshotSessionFiles(t *testing.T) {
+	t.Helper()
+
+	root := t.TempDir()
+	dateDir := filepath.Join(root, "2026", "04", "04")
+	if err := os.MkdirAll(dateDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	path := writeSessionFile(t, dateDir,
+		"ffff-ffff-ffff-ffff", "/tmp", "2026-04-04T10:00:00Z")
+
+	snap := snapshotSessionFiles(root)
+	if _, ok := snap[path]; !ok {
+		t.Fatalf("snapshotSessionFiles missing %q", path)
+	}
+	if len(snap) != 1 {
+		t.Fatalf("snapshotSessionFiles len = %d, want 1", len(snap))
 	}
 }

--- a/cmd/gemini-relay/main.go
+++ b/cmd/gemini-relay/main.go
@@ -481,7 +481,6 @@ func copyPTYOutput(src io.Reader, dst io.Writer, state *relayState) {
 	}
 }
 
-
 func (s *relayState) observeOutput(data []byte, now time.Time) {
 	if s == nil {
 		return

--- a/cmd/scuttlebot/main.go
+++ b/cmd/scuttlebot/main.go
@@ -347,7 +347,14 @@ func main() {
 	if len(cfg.LLM.Backends) > 0 {
 		llmCfg = &cfg.LLM
 	}
-	apiSrv := api.New(reg, tokens, bridgeBot, policyStore, adminStore, llmCfg, topoMgr, cfgStore, cfg.TLS.Domain, log)
+	// Pass an explicit nil interface when topology is not configured.
+	// A nil *topology.Manager passed as a topologyManager interface is
+	// non-nil (Go nil interface trap) and causes panics in setAgentModes.
+	var topoIface api.TopologyManager
+	if topoMgr != nil {
+		topoIface = topoMgr
+	}
+	apiSrv := api.New(reg, tokens, bridgeBot, policyStore, adminStore, llmCfg, topoIface, cfgStore, cfg.TLS.Domain, log)
 	handler := apiSrv.Handler()
 
 	var httpServer, tlsServer *http.Server

--- a/internal/api/channels_topology.go
+++ b/internal/api/channels_topology.go
@@ -7,12 +7,15 @@ import (
 	"github.com/conflicthq/scuttlebot/internal/topology"
 )
 
-// topologyManager is the interface the API server uses to provision channels
+// TopologyManager is the interface the API server uses to provision channels
 // and query the channel policy. Satisfied by *topology.Manager.
+type TopologyManager = topologyManager
 type topologyManager interface {
 	ProvisionChannel(ch topology.ChannelConfig) error
 	DropChannel(channel string)
 	Policy() *topology.Policy
+	GrantAccess(nick, channel, level string)
+	RevokeAccess(nick, channel string)
 }
 
 type provisionChannelRequest struct {

--- a/internal/api/chat.go
+++ b/internal/api/chat.go
@@ -18,6 +18,7 @@ type chatBridge interface {
 	Messages(channel string) []bridge.Message
 	Subscribe(channel string) (<-chan bridge.Message, func())
 	Send(ctx context.Context, channel, text, senderNick string) error
+	SendWithMeta(ctx context.Context, channel, text, senderNick string, meta *bridge.Meta) error
 	Stats() bridge.Stats
 	TouchUser(channel, nick string)
 	Users(channel string) []string
@@ -66,8 +67,9 @@ func (s *Server) handleChannelMessages(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 	channel := "#" + r.PathValue("channel")
 	var req struct {
-		Text string `json:"text"`
-		Nick string `json:"nick"`
+		Text string       `json:"text"`
+		Nick string       `json:"nick"`
+		Meta *bridge.Meta `json:"meta,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
@@ -77,7 +79,7 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "text is required")
 		return
 	}
-	if err := s.bridge.Send(r.Context(), channel, req.Text, req.Nick); err != nil {
+	if err := s.bridge.SendWithMeta(r.Context(), channel, req.Text, req.Nick, req.Meta); err != nil {
 		s.log.Error("bridge send", "channel", channel, "err", err)
 		writeError(w, http.StatusInternalServerError, "send failed")
 		return

--- a/internal/api/chat_test.go
+++ b/internal/api/chat_test.go
@@ -29,8 +29,11 @@ func (b *stubChatBridge) Subscribe(string) (<-chan bridge.Message, func()) {
 	return make(chan bridge.Message), func() {}
 }
 func (b *stubChatBridge) Send(context.Context, string, string, string) error { return nil }
-func (b *stubChatBridge) Stats() bridge.Stats                                { return bridge.Stats{} }
-func (b *stubChatBridge) Users(string) []string                              { return nil }
+func (b *stubChatBridge) SendWithMeta(_ context.Context, _, _, _ string, _ *bridge.Meta) error {
+	return nil
+}
+func (b *stubChatBridge) Stats() bridge.Stats   { return bridge.Stats{} }
+func (b *stubChatBridge) Users(string) []string { return nil }
 func (b *stubChatBridge) TouchUser(channel, nick string) {
 	b.touched = append(b.touched, struct{ channel, nick string }{channel: channel, nick: nick})
 }

--- a/internal/api/ui/index.html
+++ b/internal/api/ui/index.html
@@ -144,6 +144,7 @@ select option { background:#161b22; }
 .chat-msgs { flex:1; overflow-y:auto; padding:4px 8px; display:flex; flex-direction:column; gap:0; }
 .msg-row { font-size:13px; line-height:1.4; padding:1px 0; }
 .msg-time { color:#8b949e; font-size:11px; margin-right:6px; }
+.chat-msgs.hide-timestamps .msg-time { display:none; }
 .msg-nick { font-weight:600; margin-right:6px; }
 .msg-grouped .msg-nick { display:none; }
 .msg-grouped .msg-time { display:none; }
@@ -512,6 +513,7 @@ canvas { display:block; width:100% !important; }
         <option value="">— pick a user —</option>
       </select>
       <button class="sm" id="chat-layout-toggle" onclick="toggleChatLayout()" title="toggle compact/columnar" style="font-size:11px;padding:2px 6px">☰</button>
+      <button class="sm" id="chat-ts-toggle" onclick="toggleTimestamps()" title="toggle timestamps" style="font-size:11px;padding:2px 6px">🕐</button>
       <button class="sm" id="chat-rich-toggle" onclick="toggleRichMode()" title="toggle rich/text mode" style="font-size:11px;padding:2px 6px">✨</button>
       <button class="sm" onclick="promptHighlightWords()" title="configure highlight keywords" style="font-size:11px;padding:2px 6px">✦</button>
       <span class="stream-badge" id="chat-stream-status" style="margin-left:8px"></span>
@@ -2004,6 +2006,23 @@ function toggleChatLayout() {
 if (localStorage.getItem('sb_chat_columnar') === '1') {
   document.getElementById('chat-msgs').classList.add('columnar');
 }
+
+// --- timestamp toggle ---
+function toggleTimestamps() {
+  const el = document.getElementById('chat-msgs');
+  const hidden = el.classList.toggle('hide-timestamps');
+  localStorage.setItem('sb_hide_timestamps', hidden ? '1' : '0');
+  const btn = document.getElementById('chat-ts-toggle');
+  btn.style.color = hidden ? '#8b949e' : '';
+  btn.title = hidden ? 'timestamps hidden — click to show' : 'timestamps shown — click to hide';
+}
+(function() {
+  const hidden = localStorage.getItem('sb_hide_timestamps') === '1';
+  if (hidden) document.getElementById('chat-msgs').classList.add('hide-timestamps');
+  const btn = document.getElementById('chat-ts-toggle');
+  if (hidden) { btn.style.color = '#8b949e'; btn.title = 'timestamps hidden — click to show'; }
+  else { btn.title = 'timestamps shown — click to hide'; }
+})();
 
 // --- rich mode toggle ---
 function isRichMode() { return localStorage.getItem('sb_rich_mode') === '1'; }

--- a/internal/api/ui/index.html
+++ b/internal/api/ui/index.html
@@ -512,7 +512,7 @@ canvas { display:block; width:100% !important; }
         <option value="">— pick a user —</option>
       </select>
       <button class="sm" id="chat-layout-toggle" onclick="toggleChatLayout()" title="toggle compact/columnar" style="font-size:11px;padding:2px 6px">☰</button>
-      <button class="sm" id="chat-rich-toggle" onclick="toggleRichMode()" title="toggle rich/text mode" style="font-size:11px;padding:2px 6px">{ }</button>
+      <button class="sm" id="chat-rich-toggle" onclick="toggleRichMode()" title="toggle rich/text mode" style="font-size:11px;padding:2px 6px">✨</button>
       <button class="sm" onclick="promptHighlightWords()" title="configure highlight keywords" style="font-size:11px;padding:2px 6px">✦</button>
       <span class="stream-badge" id="chat-stream-status" style="margin-left:8px"></span>
     </div>
@@ -1917,7 +1917,7 @@ function appendMsg(msg, isHistory) {
     const html = renderMeta(msg.meta);
     if (html) {
       const show = isRichMode();
-      metaToggle = `<span class="msg-meta-toggle" style="${show ? '' : 'display:none'}" onclick="this.parentElement.nextElementSibling.classList.toggle('open');event.stopPropagation()">{ }</span>`;
+      metaToggle = `<span class="msg-meta-toggle" style="${show ? '' : 'display:none'}" onclick="this.parentElement.nextElementSibling.classList.toggle('open');event.stopPropagation()">✨</span>`;
       metaBlock = `<div class="msg-meta">${html}</div>`;
     }
   }

--- a/internal/api/ui/index.html
+++ b/internal/api/ui/index.html
@@ -1881,8 +1881,11 @@ function renderNicklist(users) {
 // Nick colors — deterministic hash over a palette
 const NICK_PALETTE = ['#58a6ff','#3fb950','#ffa657','#d2a8ff','#56d364','#79c0ff','#ff7b72','#a5d6ff','#f0883e','#39d353'];
 function nickColor(nick) {
+  // Strip session hash suffix (e.g. claude-scuttlebot-87d771ed → claude-scuttlebot)
+  // so the same agent keeps a stable color across relay restarts.
+  const base = nick.replace(/-[0-9a-f]{6,}$/i, '');
   let h = 0;
-  for (let i = 0; i < nick.length; i++) h = (h * 31 + nick.charCodeAt(i)) & 0xffff;
+  for (let i = 0; i < base.length; i++) h = (h * 31 + base.charCodeAt(i)) & 0xffff;
   return NICK_PALETTE[h % NICK_PALETTE.length];
 }
 

--- a/internal/api/ui/index.html
+++ b/internal/api/ui/index.html
@@ -2006,7 +2006,7 @@ if (localStorage.getItem('sb_chat_columnar') === '1') {
 }
 
 // --- rich mode toggle ---
-function isRichMode() { return localStorage.getItem('sb_rich_mode') !== '0'; }
+function isRichMode() { return localStorage.getItem('sb_rich_mode') === '1'; }
 function toggleRichMode() {
   const on = !isRichMode();
   localStorage.setItem('sb_rich_mode', on ? '1' : '0');

--- a/internal/api/ui/index.html
+++ b/internal/api/ui/index.html
@@ -2007,21 +2007,31 @@ if (localStorage.getItem('sb_chat_columnar') === '1') {
 
 // --- rich mode toggle ---
 function isRichMode() { return localStorage.getItem('sb_rich_mode') === '1'; }
+function applyRichToggleStyle(btn, on) {
+  if (on) {
+    btn.style.background = '#1f6feb';
+    btn.style.borderColor = '#1f6feb';
+    btn.style.color = '#fff';
+    btn.title = 'rich mode ON — click for text only';
+  } else {
+    btn.style.background = '';
+    btn.style.borderColor = '';
+    btn.style.color = '#8b949e';
+    btn.title = 'text only — click for rich mode';
+  }
+}
 function toggleRichMode() {
   const on = !isRichMode();
   localStorage.setItem('sb_rich_mode', on ? '1' : '0');
   const btn = document.getElementById('chat-rich-toggle');
-  btn.style.color = on ? '' : '#8b949e';
-  btn.title = on ? 'rich mode on — click for text only' : 'text only — click for rich mode';
+  applyRichToggleStyle(btn, on);
   // Toggle all existing meta blocks visibility.
   document.querySelectorAll('.msg-meta-toggle').forEach(el => { el.style.display = on ? '' : 'none'; });
   if (!on) document.querySelectorAll('.msg-meta.open').forEach(el => el.classList.remove('open'));
 }
 // Initialize toggle button state on load.
 (function() {
-  const btn = document.getElementById('chat-rich-toggle');
-  if (!isRichMode()) { btn.style.color = '#8b949e'; btn.title = 'text only — click for rich mode'; }
-  else { btn.title = 'rich mode on — click for text only'; }
+  applyRichToggleStyle(document.getElementById('chat-rich-toggle'), isRichMode());
 })();
 
 // --- meta renderers ---

--- a/internal/api/ui/index.html
+++ b/internal/api/ui/index.html
@@ -1881,11 +1881,8 @@ function renderNicklist(users) {
 // Nick colors — deterministic hash over a palette
 const NICK_PALETTE = ['#58a6ff','#3fb950','#ffa657','#d2a8ff','#56d364','#79c0ff','#ff7b72','#a5d6ff','#f0883e','#39d353'];
 function nickColor(nick) {
-  // Strip session hash suffix (e.g. claude-scuttlebot-87d771ed → claude-scuttlebot)
-  // so the same agent keeps a stable color across relay restarts.
-  const base = nick.replace(/-[0-9a-f]{6,}$/i, '');
   let h = 0;
-  for (let i = 0; i < base.length; i++) h = (h * 31 + base.charCodeAt(i)) & 0xffff;
+  for (let i = 0; i < nick.length; i++) h = (h * 31 + nick.charCodeAt(i)) & 0xffff;
   return NICK_PALETTE[h % NICK_PALETTE.length];
 }
 

--- a/internal/api/ui/index.html
+++ b/internal/api/ui/index.html
@@ -177,6 +177,25 @@ select option { background:#161b22; }
 .msg-row.hl-danger { background:#f8514918; border-left:2px solid #f85149; padding-left:6px; }
 .msg-row.hl-system { opacity:0.6; font-style:italic; }
 .msg-text .hl-word { background:#f0883e33; border-radius:2px; padding:0 2px; }
+/* meta blocks */
+.msg-meta { display:none; margin:2px 0 4px 0; padding:8px 10px; background:#0d1117; border:1px solid #21262d; border-radius:6px; font-size:12px; line-height:1.5; cursor:default; }
+.msg-meta.open { display:block; }
+.msg-meta-toggle { display:inline-block; margin-left:6px; font-size:10px; color:#8b949e; cursor:pointer; padding:0 4px; border:1px solid #30363d; border-radius:3px; vertical-align:middle; }
+.msg-meta-toggle:hover { color:#e6edf3; border-color:#58a6ff; }
+.msg-meta .meta-type { font-size:10px; text-transform:uppercase; letter-spacing:.06em; color:#8b949e; margin-bottom:4px; }
+.msg-meta .meta-tool { color:#d2a8ff; font-weight:600; }
+.msg-meta .meta-file { color:#79c0ff; }
+.msg-meta .meta-cmd { color:#a5d6ff; font-family:inherit; }
+.msg-meta .meta-error { color:#ff7b72; }
+.msg-meta .meta-status { display:inline-block; padding:1px 6px; border-radius:3px; font-size:11px; }
+.msg-meta .meta-status.ok { background:#3fb95022; color:#3fb950; border:1px solid #3fb95044; }
+.msg-meta .meta-status.error { background:#f8514922; color:#f85149; border:1px solid #f8514944; }
+.msg-meta .meta-status.running { background:#1f6feb22; color:#58a6ff; border:1px solid #1f6feb44; }
+.msg-meta .meta-kv { display:grid; grid-template-columns:auto 1fr; gap:2px 10px; }
+.msg-meta .meta-kv dt { color:#8b949e; }
+.msg-meta .meta-kv dd { color:#e6edf3; word-break:break-all; }
+.msg-meta pre { margin:4px 0 0; padding:6px 8px; background:#161b22; border:1px solid #21262d; border-radius:4px; overflow-x:auto; white-space:pre-wrap; word-break:break-all; color:#e6edf3; font-size:12px; }
+.msg-meta img { max-width:100%; max-height:300px; border-radius:4px; margin-top:4px; }
 .chat-input { padding:9px 13px; padding-bottom:calc(9px + env(safe-area-inset-bottom, 0px)); border-top:1px solid #30363d; display:flex; gap:7px; flex-shrink:0; background:#161b22; }
 
 /* channels tab */
@@ -493,6 +512,7 @@ canvas { display:block; width:100% !important; }
         <option value="">— pick a user —</option>
       </select>
       <button class="sm" id="chat-layout-toggle" onclick="toggleChatLayout()" title="toggle compact/columnar" style="font-size:11px;padding:2px 6px">☰</button>
+      <button class="sm" id="chat-rich-toggle" onclick="toggleRichMode()" title="toggle rich/text mode" style="font-size:11px;padding:2px 6px">{ }</button>
       <button class="sm" onclick="promptHighlightWords()" title="configure highlight keywords" style="font-size:11px;padding:2px 6px">✦</button>
       <span class="stream-badge" id="chat-stream-status" style="margin-left:8px"></span>
     </div>
@@ -1890,10 +1910,22 @@ function appendMsg(msg, isHistory) {
 
   const row = document.createElement('div');
   row.className = 'msg-row' + (grouped ? ' msg-grouped' : '');
+  // Build meta toggle if metadata present and rich mode is on.
+  let metaToggle = '';
+  let metaBlock = '';
+  if (msg.meta && msg.meta.type) {
+    const html = renderMeta(msg.meta);
+    if (html) {
+      const show = isRichMode();
+      metaToggle = `<span class="msg-meta-toggle" style="${show ? '' : 'display:none'}" onclick="this.parentElement.nextElementSibling.classList.toggle('open');event.stopPropagation()">{ }</span>`;
+      metaBlock = `<div class="msg-meta">${html}</div>`;
+    }
+  }
+
   row.innerHTML =
     `<span class="msg-time" title="${esc(new Date(msg.at).toLocaleString())}">${esc(timeStr)}</span>` +
     `<span class="msg-nick" style="color:${color}">[${esc(displayNick)}]:</span>` +
-    `<span class="msg-text">${highlightText(esc(displayText))}</span>`;
+    `<span class="msg-text">${highlightText(esc(displayText))}${metaToggle}</span>`;
 
   // Apply row-level highlights.
   const myNick = localStorage.getItem('sb_username') || '';
@@ -1909,6 +1941,12 @@ function appendMsg(msg, isHistory) {
   }
 
   area.appendChild(row);
+  // Append meta block after the row so toggle can find it via nextElementSibling.
+  if (metaBlock) {
+    const metaEl = document.createElement('div');
+    metaEl.innerHTML = metaBlock;
+    area.appendChild(metaEl.firstChild);
+  }
 
   // Unread badge when chat tab not active
   if (!isHistory && !document.getElementById('tab-chat').classList.contains('active')) {
@@ -1965,6 +2003,85 @@ function toggleChatLayout() {
 // Restore layout preference on load.
 if (localStorage.getItem('sb_chat_columnar') === '1') {
   document.getElementById('chat-msgs').classList.add('columnar');
+}
+
+// --- rich mode toggle ---
+function isRichMode() { return localStorage.getItem('sb_rich_mode') !== '0'; }
+function toggleRichMode() {
+  const on = !isRichMode();
+  localStorage.setItem('sb_rich_mode', on ? '1' : '0');
+  const btn = document.getElementById('chat-rich-toggle');
+  btn.style.color = on ? '' : '#8b949e';
+  btn.title = on ? 'rich mode on — click for text only' : 'text only — click for rich mode';
+  // Toggle all existing meta blocks visibility.
+  document.querySelectorAll('.msg-meta-toggle').forEach(el => { el.style.display = on ? '' : 'none'; });
+  if (!on) document.querySelectorAll('.msg-meta.open').forEach(el => el.classList.remove('open'));
+}
+// Initialize toggle button state on load.
+(function() {
+  const btn = document.getElementById('chat-rich-toggle');
+  if (!isRichMode()) { btn.style.color = '#8b949e'; btn.title = 'text only — click for rich mode'; }
+  else { btn.title = 'rich mode on — click for text only'; }
+})();
+
+// --- meta renderers ---
+function renderMeta(meta) {
+  if (!meta || !meta.type || !meta.data) return null;
+  switch (meta.type) {
+    case 'tool_result': return renderToolResult(meta.data);
+    case 'diff':        return renderDiff(meta.data);
+    case 'error':       return renderError(meta.data);
+    case 'status':      return renderStatus(meta.data);
+    case 'artifact':    return renderArtifact(meta.data);
+    case 'image':       return renderImage(meta.data);
+    default:            return renderGeneric(meta);
+  }
+}
+function renderToolResult(d) {
+  let html = '<div class="meta-type">tool call</div><dl class="meta-kv">';
+  html += '<dt>tool</dt><dd class="meta-tool">' + esc(d.tool || '?') + '</dd>';
+  if (d.file)    html += '<dt>file</dt><dd class="meta-file">' + esc(d.file) + '</dd>';
+  if (d.command) html += '<dt>command</dt><dd class="meta-cmd">' + esc(d.command) + '</dd>';
+  if (d.pattern) html += '<dt>pattern</dt><dd>' + esc(d.pattern) + '</dd>';
+  if (d.query)   html += '<dt>query</dt><dd>' + esc(d.query) + '</dd>';
+  if (d.url)     html += '<dt>url</dt><dd>' + esc(d.url) + '</dd>';
+  if (d.result)  html += '<dt>result</dt><dd>' + esc(d.result) + '</dd>';
+  html += '</dl>';
+  return html;
+}
+function renderDiff(d) {
+  let html = '<div class="meta-type">diff</div>';
+  if (d.file) html += '<div class="meta-file">' + esc(d.file) + '</div>';
+  if (d.hunks) html += '<pre>' + esc(typeof d.hunks === 'string' ? d.hunks : JSON.stringify(d.hunks, null, 2)) + '</pre>';
+  return html;
+}
+function renderError(d) {
+  let html = '<div class="meta-type meta-error">error</div>';
+  html += '<div class="meta-error">' + esc(d.message || '') + '</div>';
+  if (d.stack) html += '<pre>' + esc(d.stack) + '</pre>';
+  return html;
+}
+function renderStatus(d) {
+  const state = (d.state || 'running').toLowerCase();
+  const cls = state === 'ok' || state === 'success' || state === 'done' ? 'ok' : state === 'error' || state === 'failed' ? 'error' : 'running';
+  let html = '<div class="meta-type">status</div>';
+  html += '<span class="meta-status ' + cls + '">' + esc(d.state || '') + '</span>';
+  if (d.message) html += ' <span>' + esc(d.message) + '</span>';
+  return html;
+}
+function renderArtifact(d) {
+  let html = '<div class="meta-type">artifact</div>';
+  html += '<div class="meta-file">' + esc(d.name || d.path || '?') + '</div>';
+  if (d.language) html += '<span class="tag perm">' + esc(d.language) + '</span>';
+  return html;
+}
+function renderImage(d) {
+  let html = '<div class="meta-type">image</div>';
+  if (d.url) html += '<img src="' + esc(d.url) + '" alt="' + esc(d.alt || '') + '" loading="lazy">';
+  return html;
+}
+function renderGeneric(meta) {
+  return '<div class="meta-type">' + esc(meta.type) + '</div><pre>' + esc(JSON.stringify(meta.data, null, 2)) + '</pre>';
 }
 
 async function sendMsg() {

--- a/internal/bots/bridge/bridge.go
+++ b/internal/bots/bridge/bridge.go
@@ -7,6 +7,7 @@ package bridge
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net"
@@ -22,12 +23,20 @@ import (
 const botNick = "bridge"
 const defaultWebUserTTL = 5 * time.Minute
 
+// Meta is optional structured metadata attached to a bridge message.
+// IRC sees only the plain text; the web UI uses Meta for rich rendering.
+type Meta struct {
+	Type string          `json:"type"`
+	Data json.RawMessage `json:"data"`
+}
+
 // Message is a single IRC message captured by the bridge.
 type Message struct {
 	At      time.Time `json:"at"`
 	Channel string    `json:"channel"`
 	Nick    string    `json:"nick"`
 	Text    string    `json:"text"`
+	Meta    *Meta     `json:"meta,omitempty"`
 }
 
 // ringBuf is a fixed-capacity circular buffer of Messages.
@@ -319,6 +328,13 @@ func (b *Bot) Subscribe(channel string) (<-chan Message, func()) {
 // via a visible prefix: "[senderNick] text". The sent message is also pushed
 // directly into the buffer since IRC servers don't echo messages back to sender.
 func (b *Bot) Send(ctx context.Context, channel, text, senderNick string) error {
+	return b.SendWithMeta(ctx, channel, text, senderNick, nil)
+}
+
+// SendWithMeta sends a message to channel with optional structured metadata.
+// IRC receives only the plain text; SSE subscribers receive the full message
+// including meta for rich rendering in the web UI.
+func (b *Bot) SendWithMeta(ctx context.Context, channel, text, senderNick string, meta *Meta) error {
 	if b.client == nil {
 		return fmt.Errorf("bridge: not connected")
 	}
@@ -328,13 +344,10 @@ func (b *Bot) Send(ctx context.Context, channel, text, senderNick string) error 
 	}
 	b.client.Cmd.Message(channel, ircText)
 
-	// Track web sender as active in this channel.
 	if senderNick != "" {
 		b.TouchUser(channel, senderNick)
 	}
 
-	// Buffer the outgoing message immediately (server won't echo it back).
-	// Use senderNick so the web UI shows who actually sent it.
 	displayNick := b.nick
 	if senderNick != "" {
 		displayNick = senderNick
@@ -344,6 +357,7 @@ func (b *Bot) Send(ctx context.Context, channel, text, senderNick string) error 
 		Channel: channel,
 		Nick:    displayNick,
 		Text:    text,
+		Meta:    meta,
 	})
 	return nil
 }

--- a/pkg/sessionrelay/http.go
+++ b/pkg/sessionrelay/http.go
@@ -93,23 +93,35 @@ func (c *httpConnector) registerAgent(ctx context.Context) error {
 }
 
 func (c *httpConnector) Post(ctx context.Context, text string) error {
+	return c.PostWithMeta(ctx, text, nil)
+}
+
+func (c *httpConnector) PostTo(ctx context.Context, channel, text string) error {
+	return c.PostToWithMeta(ctx, channel, text, nil)
+}
+
+func (c *httpConnector) PostWithMeta(ctx context.Context, text string, meta json.RawMessage) error {
 	for _, channel := range c.Channels() {
-		if err := c.PostTo(ctx, channel, text); err != nil {
+		if err := c.PostToWithMeta(ctx, channel, text, meta); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (c *httpConnector) PostTo(ctx context.Context, channel, text string) error {
+func (c *httpConnector) PostToWithMeta(ctx context.Context, channel, text string, meta json.RawMessage) error {
 	channel = channelSlug(channel)
 	if channel == "" {
 		return fmt.Errorf("sessionrelay: post channel is required")
 	}
-	return c.postJSON(ctx, "/v1/channels/"+channel+"/messages", map[string]string{
+	body := map[string]any{
 		"nick": c.nick,
 		"text": text,
-	})
+	}
+	if len(meta) > 0 {
+		body["meta"] = json.RawMessage(meta)
+	}
+	return c.postJSON(ctx, "/v1/channels/"+channel+"/messages", body)
 }
 
 func (c *httpConnector) MessagesSince(ctx context.Context, since time.Time) ([]Message, error) {

--- a/pkg/sessionrelay/irc.go
+++ b/pkg/sessionrelay/irc.go
@@ -216,6 +216,15 @@ func (c *ircConnector) keepAlive(ctx context.Context, host string, port int) {
 }
 
 func (c *ircConnector) Post(_ context.Context, text string) error {
+	return c.PostWithMeta(context.Background(), text, nil)
+}
+
+func (c *ircConnector) PostTo(_ context.Context, channel, text string) error {
+	return c.PostToWithMeta(context.Background(), channel, text, nil)
+}
+
+// PostWithMeta sends text to all channels. Meta is ignored — IRC is text-only.
+func (c *ircConnector) PostWithMeta(_ context.Context, text string, _ json.RawMessage) error {
 	c.mu.RLock()
 	client := c.client
 	c.mu.RUnlock()
@@ -228,7 +237,8 @@ func (c *ircConnector) Post(_ context.Context, text string) error {
 	return nil
 }
 
-func (c *ircConnector) PostTo(_ context.Context, channel, text string) error {
+// PostToWithMeta sends text to a specific channel. Meta is ignored — IRC is text-only.
+func (c *ircConnector) PostToWithMeta(_ context.Context, channel, text string, _ json.RawMessage) error {
 	c.mu.RLock()
 	client := c.client
 	c.mu.RUnlock()

--- a/pkg/sessionrelay/sessionrelay.go
+++ b/pkg/sessionrelay/sessionrelay.go
@@ -2,6 +2,7 @@ package sessionrelay
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -49,6 +50,8 @@ type Connector interface {
 	Connect(ctx context.Context) error
 	Post(ctx context.Context, text string) error
 	PostTo(ctx context.Context, channel, text string) error
+	PostWithMeta(ctx context.Context, text string, meta json.RawMessage) error
+	PostToWithMeta(ctx context.Context, channel, text string, meta json.RawMessage) error
 	MessagesSince(ctx context.Context, since time.Time) ([]Message, error)
 	Touch(ctx context.Context) error
 	JoinChannel(ctx context.Context, channel string) error


### PR DESCRIPTION
## Summary

Closes #57

- Adds optional `Meta` field (`{type, data}`) to bridge messages — IRC sees plain text, web UI gets structured metadata for rich rendering
- Extends `POST /v1/channels/{ch}/messages` to accept optional `meta` JSON field, flows through SSE stream automatically
- Adds `PostWithMeta`/`PostToWithMeta` to the sessionrelay `Connector` interface (HTTP connector passes meta in POST body, IRC connector ignores it)
- Claude relay and Codex relay now emit `tool_result` metadata alongside plain text summaries for tool calls
- Web UI renders expandable meta blocks (tool calls, diffs, errors, status cards, artifacts, images) with a `{ }` toggle for rich/text mode

## Test plan

- [x] `go test ./...` passes
- [x] `golangci-lint run` clean
- [x] Cross-compiled and deployed to irc.scuttlebot.net
- [ ] Open web UI, join a channel with an active relay — verify `{ }` toggle appears in chat topbar
- [ ] Send a message with meta via API: `curl -X POST -H "Authorization: Bearer $TOKEN" -d '{"text":"edit main.go","nick":"test","meta":{"type":"tool_result","data":{"tool":"Edit","file":"main.go"}}}' http://localhost:8080/v1/channels/general/messages`
- [ ] Verify meta block appears as expandable in web UI
- [ ] Toggle rich mode off — verify meta toggles disappear
- [ ] Verify IRC clients see only plain text (no JSON metadata)