### PR TITLE
add audit support for user join and part events

### DIFF
--- a/internal/bots/auditbot/auditbot.go
+++ b/internal/bots/auditbot/auditbot.go
@@ -37,6 +37,12 @@ const (
 	KindRegistry EventKind = "registry"
 )
 
+// Event types for user presence changes.
+const (
+	EventUserJoin = "user.join"
+	EventUserPart = "user.part"
+)
+
 // Entry is an immutable audit record.
 type Entry struct {
 	At          time.Time
@@ -156,46 +162,45 @@ func (b *Bot) Start(ctx context.Context) error {
 			MessageID:   env.ID,
 		})
 	})
-    c.Handlers.AddBg(girc.JOIN, func(_ *girc.Client, e girc.Event) {
-	if len(e.Params) == 0 {
-		return
-	}
-
-	
-	if !b.shouldAudit(EventUserJoin) {
-		return
-	}
-
-	channel := e.Params[0]
-	nick := extractNick(e)
-
-	b.write(Entry{
-		Kind:        KindIRC,
-		Channel:     channel,
-		Nick:        nick,
-		MessageType: EventUserJoin,
+	c.Handlers.AddBg(girc.JOIN, func(_ *girc.Client, e girc.Event) {
+		if len(e.Params) == 0 {
+			return
+		}
+		if !b.shouldAudit(EventUserJoin) {
+			return
+		}
+		channel := e.Params[0]
+		nick := ""
+		if e.Source != nil {
+			nick = e.Source.Name
+		}
+		b.write(Entry{
+			Kind:        KindIRC,
+			Channel:     channel,
+			Nick:        nick,
+			MessageType: EventUserJoin,
+		})
 	})
-})
 
-c.Handlers.AddBg(girc.PART, func(_ *girc.Client, e girc.Event) {
-	if len(e.Params) == 0 {
-		return
-	}
-     if !b.shouldAudit(EventUserPart) {
-		return
-	channel := e.Params[0]
-	nick := ""
-	if e.Source != nil {
-		nick = e.Source.Name
-	}
-
-	b.write(Entry{
-		Kind:        KindIRC,
-		Channel:     channel,
-		Nick:        nick,
-		MessageType: "user.part",
+	c.Handlers.AddBg(girc.PART, func(_ *girc.Client, e girc.Event) {
+		if len(e.Params) == 0 {
+			return
+		}
+		if !b.shouldAudit(EventUserPart) {
+			return
+		}
+		channel := e.Params[0]
+		nick := ""
+		if e.Source != nil {
+			nick = e.Source.Name
+		}
+		b.write(Entry{
+			Kind:        KindIRC,
+			Channel:     channel,
+			Nick:        nick,
+			MessageType: EventUserPart,
+		})
 	})
-})
 	b.client = c
 
 	errCh := make(chan error, 1)
@@ -232,13 +237,13 @@ func (b *Bot) shouldAudit(msgType string) bool {
 func (b *Bot) write(e Entry) {
 	e.At = time.Now()
 	if err := b.store.Append(e); err != nil {
-		b.log.Error("failed to write audit entry",
-	"type", e.MessageType,
-	"nick", e.Nick,
-	"channel", e.Channel,
-	"kind", e.Kind,
-	"err", err,
-)
+		b.log.Error("auditbot: failed to write entry",
+			"type", e.MessageType,
+			"nick", e.Nick,
+			"channel", e.Channel,
+			"kind", e.Kind,
+			"err", err,
+		)
 	}
 }
 


### PR DESCRIPTION
This PR adds support for auditing IRC JOIN and PART events.

# Changes
- Capture user join events (`user.join`)
- Capture user part events (`user.part`)
- Apply audit type filtering for consistency
- Improve structured logging in `write()`

# Notes
- No breaking changes
- Follows existing audit event structure