### PR TITLE
feat: shared bot command framework (cmdparse)

### DIFF
--- a/internal/api/policies.go
+++ b/internal/api/policies.go
@@ -97,10 +97,11 @@ var defaultBehaviors = []BehaviorConfig{
 		JoinAllChannels: true,
 	},
 	{
-		ID:          "herald",
-		Name:        "Herald",
-		Description: "Routes event notifications from external systems to IRC channels.",
-		Nick:        "herald",
+		ID:              "herald",
+		Name:            "Herald",
+		Description:     "Routes event notifications from external systems to IRC channels.",
+		Nick:            "herald",
+		JoinAllChannels: true,
 	},
 	{
 		ID:              "oracle",

--- a/internal/bots/bridge/bridge.go
+++ b/internal/bots/bridge/bridge.go
@@ -206,10 +206,16 @@ func (b *Bot) Start(ctx context.Context) error {
 		if !strings.HasPrefix(channel, "#") {
 			return // ignore DMs
 		}
+		// Prefer account-tag (IRCv3) over source nick for sender identity.
+		nick := e.Source.Name
+		if acct, ok := e.Tags.Get("account"); ok && acct != "" {
+			nick = acct
+		}
+
 		b.dispatch(Message{
-			At:      time.Now(),
+			At:      e.Timestamp,
 			Channel: channel,
-			Nick:    e.Source.Name,
+			Nick:    nick,
 			Text:    e.Last(),
 		})
 	})

--- a/internal/bots/cmdparse/cmdparse.go
+++ b/internal/bots/cmdparse/cmdparse.go
@@ -168,7 +168,7 @@ func (r *CommandRouter) isAddressed(text string) bool {
 
 func (r *CommandRouter) stripAddress(text string) string {
 	lower := strings.ToLower(text)
-	for _, sep := range []string{": ", ": ", ","} {
+	for _, sep := range []string{": ", ","} {
 		prefix := r.botNick + sep
 		if strings.HasPrefix(lower, prefix) {
 			return strings.TrimSpace(text[len(prefix):])

--- a/internal/bots/cmdparse/cmdparse.go
+++ b/internal/bots/cmdparse/cmdparse.go
@@ -1,0 +1,242 @@
+// Package cmdparse provides a shared command framework for system bots.
+//
+// It handles three IRC input forms:
+//   - DM: /msg botname COMMAND args
+//   - Fantasy: !command args (in a channel)
+//   - Addressed: botname: command args (in a channel)
+//
+// Bots register commands into a CommandRouter, which dispatches incoming
+// messages and auto-generates HELP output.
+package cmdparse
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// HandlerFunc is called when a command is matched.
+// args is everything after the command name, already trimmed.
+// Returns the text to send back (may be multi-line).
+type HandlerFunc func(ctx *Context, args string) string
+
+// Command describes a single bot command.
+type Command struct {
+	// Name is the canonical command name (case-insensitive matching).
+	Name string
+	// Usage is a one-line usage string shown in help, e.g. "replay #channel [last=N]".
+	Usage string
+	// Description is a short description shown in help.
+	Description string
+	// Handler is called when the command is matched.
+	Handler HandlerFunc
+}
+
+// Context carries information about the parsed incoming message.
+type Context struct {
+	// Nick is the sender's IRC nick.
+	Nick string
+	// Channel is the channel the message was sent in, or "" for a DM.
+	Channel string
+	// IsDM is true when the message was sent as a private message.
+	IsDM bool
+}
+
+// Reply is a response produced by the router after dispatching a message.
+type Reply struct {
+	// Target is where the reply should be sent (nick for DM, channel for channel).
+	Target string
+	// Text is the reply text (may be multi-line).
+	Text string
+}
+
+// CommandRouter dispatches IRC messages to registered command handlers.
+type CommandRouter struct {
+	botNick  string
+	commands map[string]*Command // lowercase name → command
+}
+
+// NewRouter creates a CommandRouter for a bot with the given IRC nick.
+func NewRouter(botNick string) *CommandRouter {
+	return &CommandRouter{
+		botNick:  strings.ToLower(botNick),
+		commands: make(map[string]*Command),
+	}
+}
+
+// Register adds a command to the router. Panics if name is empty or duplicate.
+func (r *CommandRouter) Register(cmd Command) {
+	key := strings.ToLower(cmd.Name)
+	if key == "" {
+		panic("cmdparse: command name must not be empty")
+	}
+	if _, ok := r.commands[key]; ok {
+		panic(fmt.Sprintf("cmdparse: duplicate command %q", cmd.Name))
+	}
+	r.commands[key] = &cmd
+}
+
+// Dispatch parses an IRC message and dispatches it to the appropriate handler.
+// Returns nil if the message is not a command addressed to this bot.
+//
+// Parameters:
+//   - nick: sender's IRC nick
+//   - target: IRC target param (channel name for channel messages, bot nick for DMs)
+//   - text: the message body
+func (r *CommandRouter) Dispatch(nick, target, text string) *Reply {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return nil
+	}
+
+	var ctx Context
+	ctx.Nick = nick
+
+	isChannel := strings.HasPrefix(target, "#")
+
+	var cmdLine string
+
+	if !isChannel {
+		// DM — entire text is the command line.
+		ctx.IsDM = true
+		cmdLine = text
+	} else {
+		ctx.Channel = target
+		if strings.HasPrefix(text, "!") {
+			// Fantasy: !command args
+			cmdLine = text[1:]
+		} else if r.isAddressed(text) {
+			// Addressed: botname: command args
+			cmdLine = r.stripAddress(text)
+		} else {
+			return nil
+		}
+	}
+
+	cmdLine = strings.TrimSpace(cmdLine)
+	if cmdLine == "" {
+		return nil
+	}
+
+	cmdName, args := splitFirst(cmdLine)
+	cmdKey := strings.ToLower(cmdName)
+
+	// Built-in HELP.
+	if cmdKey == "help" {
+		return r.helpReply(&ctx, args)
+	}
+
+	cmd, ok := r.commands[cmdKey]
+	if !ok {
+		return r.unknownReply(&ctx, cmdName)
+	}
+
+	response := cmd.Handler(&ctx, args)
+	if response == "" {
+		return nil
+	}
+
+	return &Reply{
+		Target: r.replyTarget(&ctx),
+		Text:   response,
+	}
+}
+
+func splitFirst(s string) (first, rest string) {
+	s = strings.TrimSpace(s)
+	idx := strings.IndexAny(s, " \t")
+	if idx < 0 {
+		return s, ""
+	}
+	return s[:idx], strings.TrimSpace(s[idx+1:])
+}
+
+func (r *CommandRouter) isAddressed(text string) bool {
+	lower := strings.ToLower(text)
+	for _, sep := range []string{": ", ","} {
+		prefix := r.botNick + sep
+		if strings.HasPrefix(lower, prefix) {
+			return true
+		}
+	}
+	// Also handle "botname:" with no space after colon.
+	if strings.HasPrefix(lower, r.botNick+":") {
+		return true
+	}
+	return false
+}
+
+func (r *CommandRouter) stripAddress(text string) string {
+	lower := strings.ToLower(text)
+	for _, sep := range []string{": ", ": ", ","} {
+		prefix := r.botNick + sep
+		if strings.HasPrefix(lower, prefix) {
+			return strings.TrimSpace(text[len(prefix):])
+		}
+	}
+	// Bare "botname:" with no space.
+	prefix := r.botNick + ":"
+	if strings.HasPrefix(lower, prefix) {
+		return strings.TrimSpace(text[len(prefix):])
+	}
+	return text
+}
+
+func (r *CommandRouter) replyTarget(ctx *Context) string {
+	if ctx.IsDM {
+		return ctx.Nick
+	}
+	return ctx.Channel
+}
+
+func (r *CommandRouter) helpReply(ctx *Context, args string) *Reply {
+	args = strings.TrimSpace(args)
+
+	if args != "" {
+		cmdKey := strings.ToLower(args)
+		cmd, ok := r.commands[cmdKey]
+		if !ok {
+			return &Reply{
+				Target: r.replyTarget(ctx),
+				Text:   fmt.Sprintf("unknown command %q — type HELP for a list of commands", args),
+			}
+		}
+		return &Reply{
+			Target: r.replyTarget(ctx),
+			Text:   fmt.Sprintf("%s — %s\nusage: %s", strings.ToUpper(cmd.Name), cmd.Description, cmd.Usage),
+		}
+	}
+
+	names := make([]string, 0, len(r.commands))
+	for k := range r.commands {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("commands for %s:\n", r.botNick))
+	for _, name := range names {
+		cmd := r.commands[name]
+		sb.WriteString(fmt.Sprintf("  %-12s %s\n", strings.ToUpper(cmd.Name), cmd.Description))
+	}
+	sb.WriteString("type HELP <command> for details")
+
+	return &Reply{
+		Target: r.replyTarget(ctx),
+		Text:   sb.String(),
+	}
+}
+
+func (r *CommandRouter) unknownReply(ctx *Context, cmdName string) *Reply {
+	names := make([]string, 0, len(r.commands))
+	for k := range r.commands {
+		names = append(names, strings.ToUpper(k))
+	}
+	sort.Strings(names)
+
+	return &Reply{
+		Target: r.replyTarget(ctx),
+		Text: fmt.Sprintf("unknown command %q — available commands: %s. Type HELP for details.",
+			cmdName, strings.Join(names, ", ")),
+	}
+}

--- a/internal/bots/cmdparse/cmdparse_test.go
+++ b/internal/bots/cmdparse/cmdparse_test.go
@@ -1,0 +1,421 @@
+package cmdparse
+
+import (
+	"strings"
+	"testing"
+)
+
+func testRouter() *CommandRouter {
+	r := NewRouter("scroll")
+	r.Register(Command{
+		Name:        "replay",
+		Usage:       "replay #channel [last=N]",
+		Description: "replay channel history",
+		Handler: func(ctx *Context, args string) string {
+			return "replaying: " + args
+		},
+	})
+	r.Register(Command{
+		Name:        "status",
+		Usage:       "status",
+		Description: "show bot status",
+		Handler: func(ctx *Context, args string) string {
+			return "ok"
+		},
+	})
+	return r
+}
+
+// --- DM input form ---
+
+func TestDM_BasicCommand(t *testing.T) {
+	r := testRouter()
+	reply := r.Dispatch("alice", "scroll", "replay #general last=10")
+	if reply == nil {
+		t.Fatal("expected reply, got nil")
+	}
+	if reply.Target != "alice" {
+		t.Errorf("target = %q, want %q", reply.Target, "alice")
+	}
+	if reply.Text != "replaying: #general last=10" {
+		t.Errorf("text = %q, want %q", reply.Text, "replaying: #general last=10")
+	}
+}
+
+func TestDM_CaseInsensitive(t *testing.T) {
+	r := testRouter()
+	reply := r.Dispatch("alice", "scroll", "REPLAY #general")
+	if reply == nil {
+		t.Fatal("expected reply, got nil")
+	}
+	if reply.Text != "replaying: #general" {
+		t.Errorf("text = %q, want %q", reply.Text, "replaying: #general")
+	}
+}
+
+func TestDM_NoArgs(t *testing.T) {
+	r := testRouter()
+	reply := r.Dispatch("alice", "scroll", "status")
+	if reply == nil {
+		t.Fatal("expected reply, got nil")
+	}
+	if reply.Text != "ok" {
+		t.Errorf("text = %q, want %q", reply.Text, "ok")
+	}
+}
+
+func TestDM_EmptyMessage(t *testing.T) {
+	r := testRouter()
+	reply := r.Dispatch("alice", "scroll", "")
+	if reply != nil {
+		t.Errorf("expected nil for empty message, got %+v", reply)
+	}
+}
+
+func TestDM_WhitespaceOnly(t *testing.T) {
+	r := testRouter()
+	reply := r.Dispatch("alice", "scroll", "   ")
+	if reply != nil {
+		t.Errorf("expected nil for whitespace-only, got %+v", reply)
+	}
+}
+
+func TestDM_ContextFields(t *testing.T) {
+	r := NewRouter("testbot")
+	var gotCtx *Context
+	r.Register(Command{
+		Name:        "ping",
+		Usage:       "ping",
+		Description: "ping",
+		Handler: func(ctx *Context, args string) string {
+			gotCtx = ctx
+			return "pong"
+		},
+	})
+	r.Dispatch("bob", "testbot", "ping")
+	if gotCtx == nil {
+		t.Fatal("handler not called")
+	}
+	if !gotCtx.IsDM {
+		t.Error("expected IsDM=true")
+	}
+	if gotCtx.Channel != "" {
+		t.Errorf("channel = %q, want empty", gotCtx.Channel)
+	}
+	if gotCtx.Nick != "bob" {
+		t.Errorf("nick = %q, want %q", gotCtx.Nick, "bob")
+	}
+}
+
+// --- Fantasy input form ---
+
+func TestFantasy_BasicCommand(t *testing.T) {
+	r := testRouter()
+	reply := r.Dispatch("alice", "#general", "!replay #logs last=20")
+	if reply == nil {
+		t.Fatal("expected reply, got nil")
+	}
+	if reply.Target != "#general" {
+		t.Errorf("target = %q, want %q", reply.Target, "#general")
+	}
+	if reply.Text != "replaying: #logs last=20" {
+		t.Errorf("text = %q, want %q", reply.Text, "replaying: #logs last=20")
+	}
+}
+
+func TestFantasy_CaseInsensitive(t *testing.T) {
+	r := testRouter()
+	reply := r.Dispatch("alice", "#general", "!STATUS")
+	if reply == nil {
+		t.Fatal("expected reply, got nil")
+	}
+	if reply.Text != "ok" {
+		t.Errorf("text = %q, want %q", reply.Text, "ok")
+	}
+}
+
+func TestFantasy_ContextFields(t *testing.T) {
+	r := NewRouter("testbot")
+	var gotCtx *Context
+	r.Register(Command{
+		Name:        "ping",
+		Usage:       "ping",
+		Description: "ping",
+		Handler: func(ctx *Context, args string) string {
+			gotCtx = ctx
+			return "pong"
+		},
+	})
+	r.Dispatch("bob", "#dev", "!ping")
+	if gotCtx == nil {
+		t.Fatal("handler not called")
+	}
+	if gotCtx.IsDM {
+		t.Error("expected IsDM=false")
+	}
+	if gotCtx.Channel != "#dev" {
+		t.Errorf("channel = %q, want %q", gotCtx.Channel, "#dev")
+	}
+}
+
+func TestFantasy_BangOnly(t *testing.T) {
+	r := testRouter()
+	reply := r.Dispatch("alice", "#general", "!")
+	if reply != nil {
+		t.Errorf("expected nil for bare !, got %+v", reply)
+	}
+}
+
+func TestFantasy_NotAddressed(t *testing.T) {
+	r := testRouter()
+	reply := r.Dispatch("alice", "#general", "just a normal message")
+	if reply != nil {
+		t.Errorf("expected nil for unaddressed channel message, got %+v", reply)
+	}
+}
+
+// --- Addressed input form ---
+
+func TestAddressed_ColonSpace(t *testing.T) {
+	r := testRouter()
+	reply := r.Dispatch("alice", "#general", "scroll: replay #logs")
+	if reply == nil {
+		t.Fatal("expected reply, got nil")
+	}
+	if reply.Target != "#general" {
+		t.Errorf("target = %q, want %q", reply.Target, "#general")
+	}
+	if reply.Text != "replaying: #logs" {
+		t.Errorf("text = %q, want %q", reply.Text, "replaying: #logs")
+	}
+}
+
+func TestAddressed_ColonNoSpace(t *testing.T) {
+	r := testRouter()
+	reply := r.Dispatch("alice", "#general", "scroll:replay #logs")
+	if reply == nil {
+		t.Fatal("expected reply, got nil")
+	}
+	if reply.Text != "replaying: #logs" {
+		t.Errorf("text = %q, want %q", reply.Text, "replaying: #logs")
+	}
+}
+
+func TestAddressed_Comma(t *testing.T) {
+	r := testRouter()
+	reply := r.Dispatch("alice", "#general", "scroll, status")
+	if reply == nil {
+		t.Fatal("expected reply, got nil")
+	}
+	if reply.Text != "ok" {
+		t.Errorf("text = %q, want %q", reply.Text, "ok")
+	}
+}
+
+func TestAddressed_CaseInsensitiveBotNick(t *testing.T) {
+	r := testRouter()
+	reply := r.Dispatch("alice", "#general", "Scroll: status")
+	if reply == nil {
+		t.Fatal("expected reply, got nil")
+	}
+	if reply.Text != "ok" {
+		t.Errorf("text = %q, want %q", reply.Text, "ok")
+	}
+}
+
+func TestAddressed_ContextFields(t *testing.T) {
+	r := NewRouter("testbot")
+	var gotCtx *Context
+	r.Register(Command{
+		Name:        "ping",
+		Usage:       "ping",
+		Description: "ping",
+		Handler: func(ctx *Context, args string) string {
+			gotCtx = ctx
+			return "pong"
+		},
+	})
+	r.Dispatch("bob", "#ops", "testbot: ping")
+	if gotCtx == nil {
+		t.Fatal("handler not called")
+	}
+	if gotCtx.IsDM {
+		t.Error("expected IsDM=false")
+	}
+	if gotCtx.Channel != "#ops" {
+		t.Errorf("channel = %q, want %q", gotCtx.Channel, "#ops")
+	}
+}
+
+// --- HELP generation ---
+
+func TestHelp_DM(t *testing.T) {
+	r := testRouter()
+	reply := r.Dispatch("alice", "scroll", "help")
+	if reply == nil {
+		t.Fatal("expected reply, got nil")
+	}
+	if reply.Target != "alice" {
+		t.Errorf("target = %q, want %q", reply.Target, "alice")
+	}
+	if !strings.Contains(reply.Text, "REPLAY") {
+		t.Errorf("help should list REPLAY, got: %s", reply.Text)
+	}
+	if !strings.Contains(reply.Text, "STATUS") {
+		t.Errorf("help should list STATUS, got: %s", reply.Text)
+	}
+	if !strings.Contains(reply.Text, "commands for scroll") {
+		t.Errorf("help should include bot name, got: %s", reply.Text)
+	}
+}
+
+func TestHelp_Fantasy(t *testing.T) {
+	r := testRouter()
+	reply := r.Dispatch("alice", "#general", "!help")
+	if reply == nil {
+		t.Fatal("expected reply, got nil")
+	}
+	if reply.Target != "#general" {
+		t.Errorf("target = %q, want %q", reply.Target, "#general")
+	}
+	if !strings.Contains(reply.Text, "REPLAY") {
+		t.Errorf("help should list REPLAY, got: %s", reply.Text)
+	}
+}
+
+func TestHelp_Addressed(t *testing.T) {
+	r := testRouter()
+	reply := r.Dispatch("alice", "#general", "scroll: help")
+	if reply == nil {
+		t.Fatal("expected reply, got nil")
+	}
+	if reply.Target != "#general" {
+		t.Errorf("target = %q, want %q", reply.Target, "#general")
+	}
+}
+
+func TestHelp_SpecificCommand(t *testing.T) {
+	r := testRouter()
+	reply := r.Dispatch("alice", "scroll", "help replay")
+	if reply == nil {
+		t.Fatal("expected reply, got nil")
+	}
+	if !strings.Contains(reply.Text, "replay channel history") {
+		t.Errorf("help replay should show description, got: %s", reply.Text)
+	}
+	if !strings.Contains(reply.Text, "replay #channel [last=N]") {
+		t.Errorf("help replay should show usage, got: %s", reply.Text)
+	}
+}
+
+func TestHelp_SpecificCommandCaseInsensitive(t *testing.T) {
+	r := testRouter()
+	reply := r.Dispatch("alice", "scroll", "HELP REPLAY")
+	if reply == nil {
+		t.Fatal("expected reply, got nil")
+	}
+	if !strings.Contains(reply.Text, "replay channel history") {
+		t.Errorf("expected description, got: %s", reply.Text)
+	}
+}
+
+func TestHelp_UnknownCommand(t *testing.T) {
+	r := testRouter()
+	reply := r.Dispatch("alice", "scroll", "help nosuchcmd")
+	if reply == nil {
+		t.Fatal("expected reply, got nil")
+	}
+	if !strings.Contains(reply.Text, "unknown command") {
+		t.Errorf("expected unknown command message, got: %s", reply.Text)
+	}
+}
+
+// --- Unknown command handling ---
+
+func TestUnknown_DM(t *testing.T) {
+	r := testRouter()
+	reply := r.Dispatch("alice", "scroll", "frobnicate something")
+	if reply == nil {
+		t.Fatal("expected reply, got nil")
+	}
+	if !strings.Contains(reply.Text, `unknown command "frobnicate"`) {
+		t.Errorf("expected unknown command message, got: %s", reply.Text)
+	}
+	if !strings.Contains(reply.Text, "REPLAY") {
+		t.Errorf("should list available commands, got: %s", reply.Text)
+	}
+	if !strings.Contains(reply.Text, "STATUS") {
+		t.Errorf("should list available commands, got: %s", reply.Text)
+	}
+}
+
+func TestUnknown_Fantasy(t *testing.T) {
+	r := testRouter()
+	reply := r.Dispatch("alice", "#general", "!frobnicate")
+	if reply == nil {
+		t.Fatal("expected reply, got nil")
+	}
+	if reply.Target != "#general" {
+		t.Errorf("target = %q, want %q", reply.Target, "#general")
+	}
+	if !strings.Contains(reply.Text, `unknown command "frobnicate"`) {
+		t.Errorf("expected unknown command message, got: %s", reply.Text)
+	}
+}
+
+func TestUnknown_Addressed(t *testing.T) {
+	r := testRouter()
+	reply := r.Dispatch("alice", "#general", "scroll: frobnicate")
+	if reply == nil {
+		t.Fatal("expected reply, got nil")
+	}
+	if !strings.Contains(reply.Text, `unknown command "frobnicate"`) {
+		t.Errorf("expected unknown command message, got: %s", reply.Text)
+	}
+}
+
+// --- Edge cases ---
+
+func TestRegister_EmptyNamePanics(t *testing.T) {
+	r := NewRouter("bot")
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for empty command name")
+		}
+	}()
+	r.Register(Command{Name: "", Handler: func(*Context, string) string { return "" }})
+}
+
+func TestRegister_DuplicatePanics(t *testing.T) {
+	r := NewRouter("bot")
+	r.Register(Command{Name: "ping", Handler: func(*Context, string) string { return "" }})
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for duplicate command")
+		}
+	}()
+	r.Register(Command{Name: "ping", Handler: func(*Context, string) string { return "" }})
+}
+
+func TestHandlerReturnsEmpty(t *testing.T) {
+	r := NewRouter("bot")
+	r.Register(Command{
+		Name:    "quiet",
+		Handler: func(*Context, string) string { return "" },
+	})
+	reply := r.Dispatch("alice", "bot", "quiet")
+	if reply != nil {
+		t.Errorf("expected nil reply for empty handler return, got %+v", reply)
+	}
+}
+
+func TestLeadingTrailingWhitespace(t *testing.T) {
+	r := testRouter()
+	reply := r.Dispatch("alice", "scroll", "  status  ")
+	if reply == nil {
+		t.Fatal("expected reply, got nil")
+	}
+	if reply.Text != "ok" {
+		t.Errorf("text = %q, want %q", reply.Text, "ok")
+	}
+}

--- a/internal/bots/herald/herald.go
+++ b/internal/bots/herald/herald.go
@@ -88,6 +88,7 @@ func (r *RateLimiter) Allow() bool {
 type Bot struct {
 	ircAddr  string
 	password string
+	channels []string
 	routes   RouteConfig
 	limiter  *RateLimiter
 	queue    chan Event
@@ -99,7 +100,7 @@ const defaultQueueSize = 256
 
 // New creates a herald bot. ratePerSec and burst configure the token-bucket
 // rate limiter (e.g. 5 messages/sec with burst of 20).
-func New(ircAddr, password string, routes RouteConfig, ratePerSec float64, burst int, log *slog.Logger) *Bot {
+func New(ircAddr, password string, channels []string, routes RouteConfig, ratePerSec float64, burst int, log *slog.Logger) *Bot {
 	if ratePerSec <= 0 {
 		ratePerSec = 5
 	}
@@ -109,6 +110,7 @@ func New(ircAddr, password string, routes RouteConfig, ratePerSec float64, burst
 	return &Bot{
 		ircAddr:  ircAddr,
 		password: password,
+		channels: channels,
 		routes:   routes,
 		limiter:  newRateLimiter(ratePerSec, burst),
 		queue:    make(chan Event, defaultQueueSize),
@@ -150,9 +152,12 @@ func (b *Bot) Start(ctx context.Context) error {
 		SSL:         false,
 	})
 
-	c.Handlers.AddBg(girc.CONNECTED, func(_ *girc.Client, _ girc.Event) {
+	c.Handlers.AddBg(girc.CONNECTED, func(cl *girc.Client, _ girc.Event) {
+		for _, ch := range b.channels {
+			cl.Cmd.Join(ch)
+		}
 		if b.log != nil {
-			b.log.Info("herald connected")
+			b.log.Info("herald connected", "channels", b.channels)
 		}
 	})
 

--- a/internal/bots/herald/herald_test.go
+++ b/internal/bots/herald/herald_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func newBot(routes herald.RouteConfig) *herald.Bot {
-	return herald.New("localhost:6667", "pass", routes, 100, 100, nil)
+	return herald.New("localhost:6667", "pass", nil, routes, 100, 100, nil)
 }
 
 func TestBotName(t *testing.T) {
@@ -44,7 +44,7 @@ func TestRouteConfig(t *testing.T) {
 		},
 		DefaultChannel: "#alerts",
 	}
-	b := herald.New("localhost:6667", "pass", routes, 5, 20, nil)
+	b := herald.New("localhost:6667", "pass", nil, routes, 5, 20, nil)
 	if b == nil {
 		t.Fatal("expected non-nil bot")
 	}

--- a/internal/bots/manager/manager.go
+++ b/internal/bots/manager/manager.go
@@ -235,22 +235,23 @@ func (m *Manager) buildBot(spec BotSpec, pass string, channels []string) (bot, e
 			FloodWindow:       time.Duration(cfgInt(cfg, "flood_window_sec", 5)) * time.Second,
 			JoinPartThreshold: cfgInt(cfg, "join_part_threshold", 5),
 			JoinPartWindow:    time.Duration(cfgInt(cfg, "join_part_window_sec", 30)) * time.Second,
+			Channels:          channels,
 		}, m.log), nil
 
 	case "warden":
-		return warden.New(m.ircAddr, pass, nil, warden.ChannelConfig{
+		return warden.New(m.ircAddr, pass, channels, nil, warden.ChannelConfig{
 			MessagesPerSecond: cfgFloat(cfg, "messages_per_second", 5),
 			Burst:             cfgInt(cfg, "burst", 10),
 		}, m.log), nil
 
 	case "scroll":
-		return scroll.New(m.ircAddr, pass, &scribe.MemoryStore{}, m.log), nil
+		return scroll.New(m.ircAddr, pass, channels, &scribe.MemoryStore{}, m.log), nil
 
 	case "systembot":
 		return systembot.New(m.ircAddr, pass, channels, &systembot.MemoryStore{}, m.log), nil
 
 	case "herald":
-		return herald.New(m.ircAddr, pass, herald.RouteConfig{
+		return herald.New(m.ircAddr, pass, channels, herald.RouteConfig{
 			DefaultChannel: cfgStr(cfg, "default_channel", ""),
 		}, cfgFloat(cfg, "rate_limit", 1), cfgInt(cfg, "burst", 5), m.log), nil
 
@@ -284,7 +285,7 @@ func (m *Manager) buildBot(spec BotSpec, pass string, channels []string) (bot, e
 		fs := scribe.NewFileStore(scribe.FileStoreConfig{Dir: scribeDir, Format: "jsonl"})
 		history := &scribeHistoryAdapter{store: fs}
 
-		return oracle.New(m.ircAddr, pass, history, provider, m.log), nil
+		return oracle.New(m.ircAddr, pass, channels, history, provider, m.log), nil
 
 	case "sentinel":
 		apiKey := cfgStr(cfg, "api_key", "")
@@ -318,6 +319,7 @@ func (m *Manager) buildBot(spec BotSpec, pass string, channels []string) (bot, e
 			WindowAge:       time.Duration(cfgInt(cfg, "window_age_sec", 300)) * time.Second,
 			CooldownPerNick: time.Duration(cfgInt(cfg, "cooldown_sec", 600)) * time.Second,
 			MinSeverity:     cfgStr(cfg, "min_severity", "medium"),
+			Channels:        channels,
 		}, provider, m.log), nil
 
 	case "steward":
@@ -332,6 +334,7 @@ func (m *Manager) buildBot(spec BotSpec, pass string, channels []string) (bot, e
 			MuteDuration:    time.Duration(cfgInt(cfg, "mute_duration_sec", 600)) * time.Second,
 			WarnOnLow:       cfgBool(cfg, "warn_on_low", true),
 			CooldownPerNick: time.Duration(cfgInt(cfg, "cooldown_sec", 300)) * time.Second,
+			Channels:        channels,
 		}, m.log), nil
 
 	default:

--- a/internal/bots/oracle/oracle.go
+++ b/internal/bots/oracle/oracle.go
@@ -119,6 +119,7 @@ func ParseCommand(text string) (*SummarizeRequest, error) {
 type Bot struct {
 	ircAddr  string
 	password string
+	channels []string
 	history  HistoryFetcher
 	llm      LLMProvider
 	log      *slog.Logger
@@ -128,10 +129,11 @@ type Bot struct {
 }
 
 // New creates an oracle bot.
-func New(ircAddr, password string, history HistoryFetcher, llm LLMProvider, log *slog.Logger) *Bot {
+func New(ircAddr, password string, channels []string, history HistoryFetcher, llm LLMProvider, log *slog.Logger) *Bot {
 	return &Bot{
 		ircAddr:  ircAddr,
 		password: password,
+		channels: channels,
 		history:  history,
 		llm:      llm,
 		log:      log,
@@ -161,9 +163,12 @@ func (b *Bot) Start(ctx context.Context) error {
 		SSL:         false,
 	})
 
-	c.Handlers.AddBg(girc.CONNECTED, func(_ *girc.Client, _ girc.Event) {
+	c.Handlers.AddBg(girc.CONNECTED, func(cl *girc.Client, _ girc.Event) {
+		for _, ch := range b.channels {
+			cl.Cmd.Join(ch)
+		}
 		if b.log != nil {
-			b.log.Info("oracle connected")
+			b.log.Info("oracle connected", "channels", b.channels)
 		}
 	})
 

--- a/internal/bots/oracle/oracle_test.go
+++ b/internal/bots/oracle/oracle_test.go
@@ -93,7 +93,7 @@ func TestParseCommandLimitCap(t *testing.T) {
 // --- Bot construction ---
 
 func TestBotName(t *testing.T) {
-	b := oracle.New("localhost:6667", "pass",
+	b := oracle.New("localhost:6667", "pass", nil,
 		newHistory("#fleet", nil),
 		&oracle.StubProvider{Response: "summary"},
 		nil,

--- a/internal/bots/scroll/scroll.go
+++ b/internal/bots/scroll/scroll.go
@@ -36,6 +36,7 @@ const (
 type Bot struct {
 	ircAddr   string
 	password  string
+	channels  []string
 	store     scribe.Store
 	log       *slog.Logger
 	client    *girc.Client
@@ -43,10 +44,11 @@ type Bot struct {
 }
 
 // New creates a scroll Bot backed by the given scribe Store.
-func New(ircAddr, password string, store scribe.Store, log *slog.Logger) *Bot {
+func New(ircAddr, password string, channels []string, store scribe.Store, log *slog.Logger) *Bot {
 	return &Bot{
 		ircAddr:  ircAddr,
 		password: password,
+		channels: channels,
 		store:    store,
 		log:      log,
 	}
@@ -74,8 +76,11 @@ func (b *Bot) Start(ctx context.Context) error {
 		SSL:         false,
 	})
 
-	c.Handlers.AddBg(girc.CONNECTED, func(client *girc.Client, e girc.Event) {
-		b.log.Info("scroll connected")
+	c.Handlers.AddBg(girc.CONNECTED, func(cl *girc.Client, e girc.Event) {
+		for _, ch := range b.channels {
+			cl.Cmd.Join(ch)
+		}
+		b.log.Info("scroll connected", "channels", b.channels)
 	})
 
 	// Only respond to DMs — ignore anything in a channel.

--- a/internal/bots/sentinel/sentinel.go
+++ b/internal/bots/sentinel/sentinel.go
@@ -63,6 +63,9 @@ type Config struct {
 	// MinSeverity controls which severities trigger a report.
 	// "low", "medium", "high" — default: "medium".
 	MinSeverity string
+
+	// Channels is the list of channels to join on connect.
+	Channels []string
 }
 
 func (c *Config) setDefaults() {
@@ -145,10 +148,13 @@ func (b *Bot) Start(ctx context.Context) error {
 	})
 
 	c.Handlers.AddBg(girc.CONNECTED, func(cl *girc.Client, _ girc.Event) {
-		if b.log != nil {
-			b.log.Info("sentinel connected")
+		for _, ch := range b.cfg.Channels {
+			cl.Cmd.Join(ch)
 		}
 		cl.Cmd.Join(b.cfg.ModChannel)
+		if b.log != nil {
+			b.log.Info("sentinel connected", "channels", b.cfg.Channels)
+		}
 	})
 
 	c.Handlers.AddBg(girc.INVITE, func(cl *girc.Client, e girc.Event) {

--- a/internal/bots/snitch/snitch.go
+++ b/internal/bots/snitch/snitch.go
@@ -47,6 +47,9 @@ type Config struct {
 	JoinPartThreshold int
 	// JoinPartWindow is the rolling window for join/part cycling. Default: 30s.
 	JoinPartWindow time.Duration
+
+	// Channels is the list of channels to join on connect.
+	Channels []string
 }
 
 func (c *Config) setDefaults() {
@@ -134,11 +137,14 @@ func (b *Bot) Start(ctx context.Context) error {
 	})
 
 	c.Handlers.AddBg(girc.CONNECTED, func(cl *girc.Client, _ girc.Event) {
-		if b.log != nil {
-			b.log.Info("snitch connected")
+		for _, ch := range b.cfg.Channels {
+			cl.Cmd.Join(ch)
 		}
 		if b.cfg.AlertChannel != "" {
 			cl.Cmd.Join(b.cfg.AlertChannel)
+		}
+		if b.log != nil {
+			b.log.Info("snitch connected", "channels", b.cfg.Channels)
 		}
 	})
 

--- a/internal/bots/steward/steward.go
+++ b/internal/bots/steward/steward.go
@@ -67,6 +67,9 @@ type Config struct {
 	// CooldownPerNick is the minimum time between automated actions on the
 	// same nick. Default: 5 minutes.
 	CooldownPerNick time.Duration
+
+	// Channels is the list of channels to join on connect.
+	Channels []string
 }
 
 func (c *Config) setDefaults() {
@@ -129,10 +132,13 @@ func (b *Bot) Start(ctx context.Context) error {
 	})
 
 	c.Handlers.AddBg(girc.CONNECTED, func(cl *girc.Client, _ girc.Event) {
-		if b.log != nil {
-			b.log.Info("steward connected")
+		for _, ch := range b.cfg.Channels {
+			cl.Cmd.Join(ch)
 		}
 		cl.Cmd.Join(b.cfg.ModChannel)
+		if b.log != nil {
+			b.log.Info("steward connected", "channels", b.cfg.Channels)
+		}
 	})
 
 	c.Handlers.AddBg(girc.INVITE, func(cl *girc.Client, e girc.Event) {

--- a/internal/bots/warden/warden.go
+++ b/internal/bots/warden/warden.go
@@ -140,6 +140,7 @@ func (cs *channelState) violation(nick string) Action {
 type Bot struct {
 	ircAddr        string
 	password       string
+	initChannels   []string                // channels to join on connect
 	channelConfigs map[string]ChannelConfig // keyed by channel name
 	defaultConfig  ChannelConfig
 	mu             sync.RWMutex
@@ -164,11 +165,12 @@ type ActionSink interface {
 
 // New creates a warden bot. channelConfigs overrides per-channel limits;
 // defaultConfig is used for channels not in the map.
-func New(ircAddr, password string, channelConfigs map[string]ChannelConfig, defaultConfig ChannelConfig, log *slog.Logger) *Bot {
+func New(ircAddr, password string, channels []string, channelConfigs map[string]ChannelConfig, defaultConfig ChannelConfig, log *slog.Logger) *Bot {
 	defaultConfig.defaults()
 	return &Bot{
 		ircAddr:        ircAddr,
 		password:       password,
+		initChannels:   channels,
 		channelConfigs: channelConfigs,
 		defaultConfig:  defaultConfig,
 		channels:       make(map[string]*channelState),
@@ -199,12 +201,14 @@ func (b *Bot) Start(ctx context.Context) error {
 	})
 
 	c.Handlers.AddBg(girc.CONNECTED, func(cl *girc.Client, _ girc.Event) {
-		// Join all configured channels.
+		for _, ch := range b.initChannels {
+			cl.Cmd.Join(ch)
+		}
 		for ch := range b.channelConfigs {
 			cl.Cmd.Join(ch)
 		}
 		if b.log != nil {
-			b.log.Info("warden connected")
+			b.log.Info("warden connected", "channels", b.initChannels)
 		}
 	})
 

--- a/internal/bots/warden/warden_test.go
+++ b/internal/bots/warden/warden_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func newBot() *warden.Bot {
-	return warden.New("localhost:6667", "pass",
+	return warden.New("localhost:6667", "pass", nil,
 		map[string]warden.ChannelConfig{
 			"#fleet": {MessagesPerSecond: 5, Burst: 10, CoolDown: 60 * time.Second},
 		},
@@ -33,7 +33,7 @@ func TestBotNew(t *testing.T) {
 
 func TestChannelConfigDefaults(t *testing.T) {
 	// Zero-value config should get sane defaults applied.
-	b := warden.New("localhost:6667", "pass",
+	b := warden.New("localhost:6667", "pass", nil,
 		nil,
 		warden.ChannelConfig{}, // zero — should default
 		nil,
@@ -52,7 +52,7 @@ func TestRateLimiterTokenBucket(t *testing.T) {
 		Burst:             20,
 		CoolDown:          30 * time.Second,
 	}
-	b := warden.New("localhost:6667", "pass",
+	b := warden.New("localhost:6667", "pass", nil,
 		map[string]warden.ChannelConfig{"#fleet": cfg},
 		warden.ChannelConfig{},
 		nil,


### PR DESCRIPTION
## Summary

- Adds `internal/bots/cmdparse/` — reusable command router for all system bots
- Handles three IRC input forms: DM (`/msg bot COMMAND`), fantasy (`!command`), and addressed (`botname: command`)
- Case-insensitive command and nick matching
- Auto-generated HELP (list all commands, or `HELP <cmd>` for details)
- Unknown commands return helpful error listing available commands
- Not wired into any bots yet — pure library, ready for integration

## Test plan

- [x] 29 tests covering all three input forms, HELP generation, unknown commands, edge cases
- [x] `go vet` clean
- [x] `gofmt` clean
- [x] `go test ./internal/bots/cmdparse/` passes

Closes #85