### PR TITLE
fix: all system bots join channels on connect

### DIFF
--- a/internal/api/policies.go
+++ b/internal/api/policies.go
@@ -97,10 +97,11 @@ var defaultBehaviors = []BehaviorConfig{
 		JoinAllChannels: true,
 	},
 	{
-		ID:          "herald",
-		Name:        "Herald",
-		Description: "Routes event notifications from external systems to IRC channels.",
-		Nick:        "herald",
+		ID:              "herald",
+		Name:            "Herald",
+		Description:     "Routes event notifications from external systems to IRC channels.",
+		Nick:            "herald",
+		JoinAllChannels: true,
 	},
 	{
 		ID:              "oracle",

--- a/internal/bots/herald/herald.go
+++ b/internal/bots/herald/herald.go
@@ -88,6 +88,7 @@ func (r *RateLimiter) Allow() bool {
 type Bot struct {
 	ircAddr  string
 	password string
+	channels []string
 	routes   RouteConfig
 	limiter  *RateLimiter
 	queue    chan Event
@@ -99,7 +100,7 @@ const defaultQueueSize = 256
 
 // New creates a herald bot. ratePerSec and burst configure the token-bucket
 // rate limiter (e.g. 5 messages/sec with burst of 20).
-func New(ircAddr, password string, routes RouteConfig, ratePerSec float64, burst int, log *slog.Logger) *Bot {
+func New(ircAddr, password string, channels []string, routes RouteConfig, ratePerSec float64, burst int, log *slog.Logger) *Bot {
 	if ratePerSec <= 0 {
 		ratePerSec = 5
 	}
@@ -109,6 +110,7 @@ func New(ircAddr, password string, routes RouteConfig, ratePerSec float64, burst
 	return &Bot{
 		ircAddr:  ircAddr,
 		password: password,
+		channels: channels,
 		routes:   routes,
 		limiter:  newRateLimiter(ratePerSec, burst),
 		queue:    make(chan Event, defaultQueueSize),
@@ -150,9 +152,12 @@ func (b *Bot) Start(ctx context.Context) error {
 		SSL:         false,
 	})
 
-	c.Handlers.AddBg(girc.CONNECTED, func(_ *girc.Client, _ girc.Event) {
+	c.Handlers.AddBg(girc.CONNECTED, func(cl *girc.Client, _ girc.Event) {
+		for _, ch := range b.channels {
+			cl.Cmd.Join(ch)
+		}
 		if b.log != nil {
-			b.log.Info("herald connected")
+			b.log.Info("herald connected", "channels", b.channels)
 		}
 	})
 

--- a/internal/bots/herald/herald_test.go
+++ b/internal/bots/herald/herald_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func newBot(routes herald.RouteConfig) *herald.Bot {
-	return herald.New("localhost:6667", "pass", routes, 100, 100, nil)
+	return herald.New("localhost:6667", "pass", nil, routes, 100, 100, nil)
 }
 
 func TestBotName(t *testing.T) {
@@ -44,7 +44,7 @@ func TestRouteConfig(t *testing.T) {
 		},
 		DefaultChannel: "#alerts",
 	}
-	b := herald.New("localhost:6667", "pass", routes, 5, 20, nil)
+	b := herald.New("localhost:6667", "pass", nil, routes, 5, 20, nil)
 	if b == nil {
 		t.Fatal("expected non-nil bot")
 	}

--- a/internal/bots/manager/manager.go
+++ b/internal/bots/manager/manager.go
@@ -235,22 +235,23 @@ func (m *Manager) buildBot(spec BotSpec, pass string, channels []string) (bot, e
 			FloodWindow:       time.Duration(cfgInt(cfg, "flood_window_sec", 5)) * time.Second,
 			JoinPartThreshold: cfgInt(cfg, "join_part_threshold", 5),
 			JoinPartWindow:    time.Duration(cfgInt(cfg, "join_part_window_sec", 30)) * time.Second,
+			Channels:          channels,
 		}, m.log), nil
 
 	case "warden":
-		return warden.New(m.ircAddr, pass, nil, warden.ChannelConfig{
+		return warden.New(m.ircAddr, pass, channels, nil, warden.ChannelConfig{
 			MessagesPerSecond: cfgFloat(cfg, "messages_per_second", 5),
 			Burst:             cfgInt(cfg, "burst", 10),
 		}, m.log), nil
 
 	case "scroll":
-		return scroll.New(m.ircAddr, pass, &scribe.MemoryStore{}, m.log), nil
+		return scroll.New(m.ircAddr, pass, channels, &scribe.MemoryStore{}, m.log), nil
 
 	case "systembot":
 		return systembot.New(m.ircAddr, pass, channels, &systembot.MemoryStore{}, m.log), nil
 
 	case "herald":
-		return herald.New(m.ircAddr, pass, herald.RouteConfig{
+		return herald.New(m.ircAddr, pass, channels, herald.RouteConfig{
 			DefaultChannel: cfgStr(cfg, "default_channel", ""),
 		}, cfgFloat(cfg, "rate_limit", 1), cfgInt(cfg, "burst", 5), m.log), nil
 
@@ -284,7 +285,7 @@ func (m *Manager) buildBot(spec BotSpec, pass string, channels []string) (bot, e
 		fs := scribe.NewFileStore(scribe.FileStoreConfig{Dir: scribeDir, Format: "jsonl"})
 		history := &scribeHistoryAdapter{store: fs}
 
-		return oracle.New(m.ircAddr, pass, history, provider, m.log), nil
+		return oracle.New(m.ircAddr, pass, channels, history, provider, m.log), nil
 
 	case "sentinel":
 		apiKey := cfgStr(cfg, "api_key", "")
@@ -318,6 +319,7 @@ func (m *Manager) buildBot(spec BotSpec, pass string, channels []string) (bot, e
 			WindowAge:       time.Duration(cfgInt(cfg, "window_age_sec", 300)) * time.Second,
 			CooldownPerNick: time.Duration(cfgInt(cfg, "cooldown_sec", 600)) * time.Second,
 			MinSeverity:     cfgStr(cfg, "min_severity", "medium"),
+			Channels:        channels,
 		}, provider, m.log), nil
 
 	case "steward":
@@ -332,6 +334,7 @@ func (m *Manager) buildBot(spec BotSpec, pass string, channels []string) (bot, e
 			MuteDuration:    time.Duration(cfgInt(cfg, "mute_duration_sec", 600)) * time.Second,
 			WarnOnLow:       cfgBool(cfg, "warn_on_low", true),
 			CooldownPerNick: time.Duration(cfgInt(cfg, "cooldown_sec", 300)) * time.Second,
+			Channels:        channels,
 		}, m.log), nil
 
 	default:

--- a/internal/bots/oracle/oracle.go
+++ b/internal/bots/oracle/oracle.go
@@ -119,6 +119,7 @@ func ParseCommand(text string) (*SummarizeRequest, error) {
 type Bot struct {
 	ircAddr  string
 	password string
+	channels []string
 	history  HistoryFetcher
 	llm      LLMProvider
 	log      *slog.Logger
@@ -128,10 +129,11 @@ type Bot struct {
 }
 
 // New creates an oracle bot.
-func New(ircAddr, password string, history HistoryFetcher, llm LLMProvider, log *slog.Logger) *Bot {
+func New(ircAddr, password string, channels []string, history HistoryFetcher, llm LLMProvider, log *slog.Logger) *Bot {
 	return &Bot{
 		ircAddr:  ircAddr,
 		password: password,
+		channels: channels,
 		history:  history,
 		llm:      llm,
 		log:      log,
@@ -161,9 +163,12 @@ func (b *Bot) Start(ctx context.Context) error {
 		SSL:         false,
 	})
 
-	c.Handlers.AddBg(girc.CONNECTED, func(_ *girc.Client, _ girc.Event) {
+	c.Handlers.AddBg(girc.CONNECTED, func(cl *girc.Client, _ girc.Event) {
+		for _, ch := range b.channels {
+			cl.Cmd.Join(ch)
+		}
 		if b.log != nil {
-			b.log.Info("oracle connected")
+			b.log.Info("oracle connected", "channels", b.channels)
 		}
 	})
 

--- a/internal/bots/oracle/oracle_test.go
+++ b/internal/bots/oracle/oracle_test.go
@@ -93,7 +93,7 @@ func TestParseCommandLimitCap(t *testing.T) {
 // --- Bot construction ---
 
 func TestBotName(t *testing.T) {
-	b := oracle.New("localhost:6667", "pass",
+	b := oracle.New("localhost:6667", "pass", nil,
 		newHistory("#fleet", nil),
 		&oracle.StubProvider{Response: "summary"},
 		nil,

--- a/internal/bots/scroll/scroll.go
+++ b/internal/bots/scroll/scroll.go
@@ -36,6 +36,7 @@ const (
 type Bot struct {
 	ircAddr   string
 	password  string
+	channels  []string
 	store     scribe.Store
 	log       *slog.Logger
 	client    *girc.Client
@@ -43,10 +44,11 @@ type Bot struct {
 }
 
 // New creates a scroll Bot backed by the given scribe Store.
-func New(ircAddr, password string, store scribe.Store, log *slog.Logger) *Bot {
+func New(ircAddr, password string, channels []string, store scribe.Store, log *slog.Logger) *Bot {
 	return &Bot{
 		ircAddr:  ircAddr,
 		password: password,
+		channels: channels,
 		store:    store,
 		log:      log,
 	}
@@ -74,8 +76,11 @@ func (b *Bot) Start(ctx context.Context) error {
 		SSL:         false,
 	})
 
-	c.Handlers.AddBg(girc.CONNECTED, func(client *girc.Client, e girc.Event) {
-		b.log.Info("scroll connected")
+	c.Handlers.AddBg(girc.CONNECTED, func(cl *girc.Client, e girc.Event) {
+		for _, ch := range b.channels {
+			cl.Cmd.Join(ch)
+		}
+		b.log.Info("scroll connected", "channels", b.channels)
 	})
 
 	// Only respond to DMs — ignore anything in a channel.

--- a/internal/bots/sentinel/sentinel.go
+++ b/internal/bots/sentinel/sentinel.go
@@ -63,6 +63,9 @@ type Config struct {
 	// MinSeverity controls which severities trigger a report.
 	// "low", "medium", "high" — default: "medium".
 	MinSeverity string
+
+	// Channels is the list of channels to join on connect.
+	Channels []string
 }
 
 func (c *Config) setDefaults() {
@@ -145,10 +148,13 @@ func (b *Bot) Start(ctx context.Context) error {
 	})
 
 	c.Handlers.AddBg(girc.CONNECTED, func(cl *girc.Client, _ girc.Event) {
-		if b.log != nil {
-			b.log.Info("sentinel connected")
+		for _, ch := range b.cfg.Channels {
+			cl.Cmd.Join(ch)
 		}
 		cl.Cmd.Join(b.cfg.ModChannel)
+		if b.log != nil {
+			b.log.Info("sentinel connected", "channels", b.cfg.Channels)
+		}
 	})
 
 	c.Handlers.AddBg(girc.INVITE, func(cl *girc.Client, e girc.Event) {

--- a/internal/bots/snitch/snitch.go
+++ b/internal/bots/snitch/snitch.go
@@ -47,6 +47,9 @@ type Config struct {
 	JoinPartThreshold int
 	// JoinPartWindow is the rolling window for join/part cycling. Default: 30s.
 	JoinPartWindow time.Duration
+
+	// Channels is the list of channels to join on connect.
+	Channels []string
 }
 
 func (c *Config) setDefaults() {
@@ -134,11 +137,14 @@ func (b *Bot) Start(ctx context.Context) error {
 	})
 
 	c.Handlers.AddBg(girc.CONNECTED, func(cl *girc.Client, _ girc.Event) {
-		if b.log != nil {
-			b.log.Info("snitch connected")
+		for _, ch := range b.cfg.Channels {
+			cl.Cmd.Join(ch)
 		}
 		if b.cfg.AlertChannel != "" {
 			cl.Cmd.Join(b.cfg.AlertChannel)
+		}
+		if b.log != nil {
+			b.log.Info("snitch connected", "channels", b.cfg.Channels)
 		}
 	})
 

--- a/internal/bots/steward/steward.go
+++ b/internal/bots/steward/steward.go
@@ -67,6 +67,9 @@ type Config struct {
 	// CooldownPerNick is the minimum time between automated actions on the
 	// same nick. Default: 5 minutes.
 	CooldownPerNick time.Duration
+
+	// Channels is the list of channels to join on connect.
+	Channels []string
 }
 
 func (c *Config) setDefaults() {
@@ -129,10 +132,13 @@ func (b *Bot) Start(ctx context.Context) error {
 	})
 
 	c.Handlers.AddBg(girc.CONNECTED, func(cl *girc.Client, _ girc.Event) {
-		if b.log != nil {
-			b.log.Info("steward connected")
+		for _, ch := range b.cfg.Channels {
+			cl.Cmd.Join(ch)
 		}
 		cl.Cmd.Join(b.cfg.ModChannel)
+		if b.log != nil {
+			b.log.Info("steward connected", "channels", b.cfg.Channels)
+		}
 	})
 
 	c.Handlers.AddBg(girc.INVITE, func(cl *girc.Client, e girc.Event) {

--- a/internal/bots/warden/warden.go
+++ b/internal/bots/warden/warden.go
@@ -140,6 +140,7 @@ func (cs *channelState) violation(nick string) Action {
 type Bot struct {
 	ircAddr        string
 	password       string
+	initChannels   []string                // channels to join on connect
 	channelConfigs map[string]ChannelConfig // keyed by channel name
 	defaultConfig  ChannelConfig
 	mu             sync.RWMutex
@@ -164,11 +165,12 @@ type ActionSink interface {
 
 // New creates a warden bot. channelConfigs overrides per-channel limits;
 // defaultConfig is used for channels not in the map.
-func New(ircAddr, password string, channelConfigs map[string]ChannelConfig, defaultConfig ChannelConfig, log *slog.Logger) *Bot {
+func New(ircAddr, password string, channels []string, channelConfigs map[string]ChannelConfig, defaultConfig ChannelConfig, log *slog.Logger) *Bot {
 	defaultConfig.defaults()
 	return &Bot{
 		ircAddr:        ircAddr,
 		password:       password,
+		initChannels:   channels,
 		channelConfigs: channelConfigs,
 		defaultConfig:  defaultConfig,
 		channels:       make(map[string]*channelState),
@@ -199,12 +201,14 @@ func (b *Bot) Start(ctx context.Context) error {
 	})
 
 	c.Handlers.AddBg(girc.CONNECTED, func(cl *girc.Client, _ girc.Event) {
-		// Join all configured channels.
+		for _, ch := range b.initChannels {
+			cl.Cmd.Join(ch)
+		}
 		for ch := range b.channelConfigs {
 			cl.Cmd.Join(ch)
 		}
 		if b.log != nil {
-			b.log.Info("warden connected")
+			b.log.Info("warden connected", "channels", b.initChannels)
 		}
 	})
 

--- a/internal/bots/warden/warden_test.go
+++ b/internal/bots/warden/warden_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func newBot() *warden.Bot {
-	return warden.New("localhost:6667", "pass",
+	return warden.New("localhost:6667", "pass", nil,
 		map[string]warden.ChannelConfig{
 			"#fleet": {MessagesPerSecond: 5, Burst: 10, CoolDown: 60 * time.Second},
 		},
@@ -33,7 +33,7 @@ func TestBotNew(t *testing.T) {
 
 func TestChannelConfigDefaults(t *testing.T) {
 	// Zero-value config should get sane defaults applied.
-	b := warden.New("localhost:6667", "pass",
+	b := warden.New("localhost:6667", "pass", nil,
 		nil,
 		warden.ChannelConfig{}, // zero — should default
 		nil,
@@ -52,7 +52,7 @@ func TestRateLimiterTokenBucket(t *testing.T) {
 		Burst:             20,
 		CoolDown:          30 * time.Second,
 	}
-	b := warden.New("localhost:6667", "pass",
+	b := warden.New("localhost:6667", "pass", nil,
 		map[string]warden.ChannelConfig{"#fleet": cfg},
 		warden.ChannelConfig{},
 		nil,


### PR DESCRIPTION
## Summary
- 7 of 10 system bots (herald, oracle, warden, scroll, snitch, sentinel, steward) connected to IRC but never joined channels — their constructors didn't accept or use the channel list from the manager
- Added `channels []string` parameter to herald, oracle, scroll, warden constructors and `Channels` field to snitch, sentinel, steward Config structs
- Each bot's CONNECTED handler now joins channels on connect, matching the pattern used by the 3 working bots (auditbot, scribe, systembot)
- Fixed herald's default policy to include `join_all_channels: true` (was missing)

Closes #71

## Test plan
- [x] `go test ./...` passes
- [x] Deployed to production — all 10 bots confirmed joining `#scuttlebot #general #ops #kohakku`
- [x] Server logs show no errors from the channel join changes