### PR TITLE
feat(bridge): use IRCv3 account-tag and server-time

### DIFF
--- a/internal/bots/bridge/bridge.go
+++ b/internal/bots/bridge/bridge.go
@@ -206,10 +206,16 @@ func (b *Bot) Start(ctx context.Context) error {
 		if !strings.HasPrefix(channel, "#") {
 			return // ignore DMs
 		}
+		// Prefer account-tag (IRCv3) over source nick for sender identity.
+		nick := e.Source.Name
+		if acct, ok := e.Tags.Get("account"); ok && acct != "" {
+			nick = acct
+		}
+
 		b.dispatch(Message{
-			At:      time.Now(),
+			At:      e.Timestamp,
 			Channel: channel,
-			Nick:    e.Source.Name,
+			Nick:    nick,
 			Text:    e.Last(),
 		})
 	})


### PR DESCRIPTION
## Summary

- Use `account-tag` from IRCv3 message tags for sender identity instead of `e.Source.Name` (falls back to source nick when tag is absent)
- Use `e.Timestamp` (populated from `server-time` capability) instead of `time.Now()` for accurate message timestamps
- Both capabilities are already negotiated by girc by default — zero config changes needed

Closes #112 (Phase 1 — bridge bot only)

## Test plan

- [x] `go build ./internal/bots/bridge/` passes
- [x] `go test ./internal/bots/bridge/` passes
- [x] `go vet ./internal/bots/bridge/` passes
- [ ] Verify in running instance: messages from authenticated agents show account name, not nick
- [ ] Verify timestamps reflect server time, not bridge wall clock