### PR TITLE
feat: IRCv3 leverage — tags, MONITOR, CHATHISTORY, extended bans, +B mode

### DIFF
--- a/internal/bots/auditbot/auditbot.go
+++ b/internal/bots/auditbot/auditbot.go
@@ -122,6 +122,7 @@ func (b *Bot) Start(ctx context.Context) error {
 	})
 
 	c.Handlers.AddBg(girc.CONNECTED, func(cl *girc.Client, _ girc.Event) {
+		cl.Cmd.Mode(cl.GetNick(), "+B")
 		for _, ch := range b.channels {
 			cl.Cmd.Join(ch)
 		}

--- a/internal/bots/bridge/bridge.go
+++ b/internal/bots/bridge/bridge.go
@@ -175,6 +175,7 @@ func (b *Bot) Start(ctx context.Context) error {
 	})
 
 	c.Handlers.AddBg(girc.CONNECTED, func(cl *girc.Client, _ girc.Event) {
+		cl.Cmd.Mode(cl.GetNick(), "+B")
 		if b.log != nil {
 			b.log.Info("bridge connected")
 		}

--- a/internal/bots/bridge/bridge.go
+++ b/internal/bots/bridge/bridge.go
@@ -36,6 +36,7 @@ type Message struct {
 	Channel string    `json:"channel"`
 	Nick    string    `json:"nick"`
 	Text    string    `json:"text"`
+	MsgID   string    `json:"msgid,omitempty"`
 	Meta    *Meta     `json:"meta,omitempty"`
 }
 
@@ -221,11 +222,16 @@ func (b *Bot) Start(ctx context.Context) error {
 			nick = acct
 		}
 
+		var msgID string
+		if id, ok := e.Tags.Get("msgid"); ok {
+			msgID = id
+		}
 		b.dispatch(Message{
 			At:      e.Timestamp,
 			Channel: channel,
 			Nick:    nick,
 			Text:    e.Last(),
+			MsgID:   msgID,
 		})
 	})
 

--- a/internal/bots/herald/herald.go
+++ b/internal/bots/herald/herald.go
@@ -153,6 +153,7 @@ func (b *Bot) Start(ctx context.Context) error {
 	})
 
 	c.Handlers.AddBg(girc.CONNECTED, func(cl *girc.Client, _ girc.Event) {
+		cl.Cmd.Mode(cl.GetNick(), "+B")
 		for _, ch := range b.channels {
 			cl.Cmd.Join(ch)
 		}

--- a/internal/bots/oracle/oracle.go
+++ b/internal/bots/oracle/oracle.go
@@ -22,6 +22,8 @@ import (
 	"time"
 
 	"github.com/lrstanley/girc"
+
+	"github.com/conflicthq/scuttlebot/pkg/chathistory"
 )
 
 const (
@@ -126,6 +128,7 @@ type Bot struct {
 	mu       sync.Mutex
 	lastReq  map[string]time.Time // nick → last request time
 	client   *girc.Client
+	chFetch  *chathistory.Fetcher // CHATHISTORY fetcher, nil if unsupported
 }
 
 // New creates an oracle bot.
@@ -161,15 +164,22 @@ func (b *Bot) Start(ctx context.Context) error {
 		PingDelay:   30 * time.Second,
 		PingTimeout: 30 * time.Second,
 		SSL:         false,
+		SupportedCaps: map[string][]string{
+			"draft/chathistory": nil,
+			"chathistory":       nil,
+		},
 	})
+
+	b.chFetch = chathistory.New(c)
 
 	c.Handlers.AddBg(girc.CONNECTED, func(cl *girc.Client, _ girc.Event) {
 		cl.Cmd.Mode(cl.GetNick(), "+B")
 		for _, ch := range b.channels {
 			cl.Cmd.Join(ch)
 		}
+		hasCH := cl.HasCapability("chathistory") || cl.HasCapability("draft/chathistory")
 		if b.log != nil {
-			b.log.Info("oracle connected", "channels", b.channels)
+			b.log.Info("oracle connected", "channels", b.channels, "chathistory", hasCH)
 		}
 	})
 
@@ -237,8 +247,8 @@ func (b *Bot) handle(ctx context.Context, cl *girc.Client, nick, text string) {
 	b.lastReq[nick] = time.Now()
 	b.mu.Unlock()
 
-	// Fetch history.
-	entries, err := b.history.Query(req.Channel, req.Limit)
+	// Fetch history — prefer CHATHISTORY if available, fall back to store.
+	entries, err := b.fetchHistory(ctx, req.Channel, req.Limit)
 	if err != nil {
 		cl.Cmd.Notice(nick, fmt.Sprintf("oracle: failed to fetch history for %s: %v", req.Channel, err))
 		return
@@ -265,6 +275,35 @@ func (b *Bot) handle(ctx context.Context, cl *girc.Client, nick, text string) {
 			cl.Cmd.Notice(nick, line)
 		}
 	}
+}
+
+func (b *Bot) fetchHistory(ctx context.Context, channel string, limit int) ([]HistoryEntry, error) {
+	if b.chFetch != nil && b.client != nil {
+		hasCH := b.client.HasCapability("chathistory") || b.client.HasCapability("draft/chathistory")
+		if hasCH {
+			chCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			defer cancel()
+			msgs, err := b.chFetch.Latest(chCtx, channel, limit)
+			if err == nil {
+				entries := make([]HistoryEntry, len(msgs))
+				for i, m := range msgs {
+					nick := m.Nick
+					if m.Account != "" {
+						nick = m.Account
+					}
+					entries[i] = HistoryEntry{
+						Nick: nick,
+						Raw:  m.Text,
+					}
+				}
+				return entries, nil
+			}
+			if b.log != nil {
+				b.log.Warn("chathistory failed, falling back to store", "err", err)
+			}
+		}
+	}
+	return b.history.Query(channel, limit)
 }
 
 func buildPrompt(channel string, entries []HistoryEntry) string {

--- a/internal/bots/oracle/oracle.go
+++ b/internal/bots/oracle/oracle.go
@@ -164,6 +164,7 @@ func (b *Bot) Start(ctx context.Context) error {
 	})
 
 	c.Handlers.AddBg(girc.CONNECTED, func(cl *girc.Client, _ girc.Event) {
+		cl.Cmd.Mode(cl.GetNick(), "+B")
 		for _, ch := range b.channels {
 			cl.Cmd.Join(ch)
 		}

--- a/internal/bots/scribe/scribe.go
+++ b/internal/bots/scribe/scribe.go
@@ -66,6 +66,7 @@ func (b *Bot) Start(ctx context.Context) error {
 	})
 
 	c.Handlers.AddBg(girc.CONNECTED, func(client *girc.Client, e girc.Event) {
+		client.Cmd.Mode(client.GetNick(), "+B")
 		for _, ch := range b.channels {
 			client.Cmd.Join(ch)
 		}

--- a/internal/bots/scroll/scroll.go
+++ b/internal/bots/scroll/scroll.go
@@ -23,6 +23,7 @@ import (
 	"github.com/lrstanley/girc"
 
 	"github.com/conflicthq/scuttlebot/internal/bots/scribe"
+	"github.com/conflicthq/scuttlebot/pkg/chathistory"
 )
 
 const (
@@ -40,7 +41,8 @@ type Bot struct {
 	store     scribe.Store
 	log       *slog.Logger
 	client    *girc.Client
-	rateLimit sync.Map // nick → last request time
+	history   *chathistory.Fetcher // nil until connected, if CHATHISTORY is available
+	rateLimit sync.Map             // nick → last request time
 }
 
 // New creates a scroll Bot backed by the given scribe Store.
@@ -74,14 +76,22 @@ func (b *Bot) Start(ctx context.Context) error {
 		PingDelay:   30 * time.Second,
 		PingTimeout: 30 * time.Second,
 		SSL:         false,
+		SupportedCaps: map[string][]string{
+			"draft/chathistory": nil,
+			"chathistory":       nil,
+		},
 	})
+
+	// Register CHATHISTORY batch handlers before connecting.
+	b.history = chathistory.New(c)
 
 	c.Handlers.AddBg(girc.CONNECTED, func(cl *girc.Client, e girc.Event) {
 		cl.Cmd.Mode(cl.GetNick(), "+B")
 		for _, ch := range b.channels {
 			cl.Cmd.Join(ch)
 		}
-		b.log.Info("scroll connected", "channels", b.channels)
+		hasCH := cl.HasCapability("chathistory") || cl.HasCapability("draft/chathistory")
+		b.log.Info("scroll connected", "channels", b.channels, "chathistory", hasCH)
 	})
 
 	// Only respond to DMs — ignore anything in a channel.
@@ -136,7 +146,7 @@ func (b *Bot) handle(client *girc.Client, nick, text string) {
 		return
 	}
 
-	entries, err := b.store.Query(req.Channel, req.Limit)
+	entries, err := b.fetchHistory(req)
 	if err != nil {
 		client.Cmd.Notice(nick, fmt.Sprintf("error fetching history: %s", err))
 		return
@@ -153,6 +163,36 @@ func (b *Bot) handle(client *girc.Client, nick, text string) {
 		client.Cmd.Notice(nick, string(line))
 	}
 	client.Cmd.Notice(nick, fmt.Sprintf("--- end replay %s ---", req.Channel))
+}
+
+// fetchHistory tries CHATHISTORY first, falls back to scribe store.
+func (b *Bot) fetchHistory(req *replayRequest) ([]scribe.Entry, error) {
+	if b.history != nil && b.client != nil {
+		hasCH := b.client.HasCapability("chathistory") || b.client.HasCapability("draft/chathistory")
+		if hasCH {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			msgs, err := b.history.Latest(ctx, req.Channel, req.Limit)
+			if err == nil {
+				entries := make([]scribe.Entry, len(msgs))
+				for i, m := range msgs {
+					entries[i] = scribe.Entry{
+						At:      m.At,
+						Channel: req.Channel,
+						Nick:    m.Nick,
+						Kind:    scribe.EntryKindRaw,
+						Raw:     m.Text,
+					}
+					if m.Account != "" {
+						entries[i].Nick = m.Account
+					}
+				}
+				return entries, nil
+			}
+			b.log.Warn("chathistory failed, falling back to store", "err", err)
+		}
+	}
+	return b.store.Query(req.Channel, req.Limit)
 }
 
 func (b *Bot) checkRateLimit(nick string) bool {

--- a/internal/bots/scroll/scroll.go
+++ b/internal/bots/scroll/scroll.go
@@ -77,6 +77,7 @@ func (b *Bot) Start(ctx context.Context) error {
 	})
 
 	c.Handlers.AddBg(girc.CONNECTED, func(cl *girc.Client, e girc.Event) {
+		cl.Cmd.Mode(cl.GetNick(), "+B")
 		for _, ch := range b.channels {
 			cl.Cmd.Join(ch)
 		}

--- a/internal/bots/sentinel/sentinel.go
+++ b/internal/bots/sentinel/sentinel.go
@@ -148,6 +148,7 @@ func (b *Bot) Start(ctx context.Context) error {
 	})
 
 	c.Handlers.AddBg(girc.CONNECTED, func(cl *girc.Client, _ girc.Event) {
+		cl.Cmd.Mode(cl.GetNick(), "+B")
 		for _, ch := range b.cfg.Channels {
 			cl.Cmd.Join(ch)
 		}

--- a/internal/bots/snitch/snitch.go
+++ b/internal/bots/snitch/snitch.go
@@ -137,6 +137,7 @@ func (b *Bot) Start(ctx context.Context) error {
 	})
 
 	c.Handlers.AddBg(girc.CONNECTED, func(cl *girc.Client, _ girc.Event) {
+		cl.Cmd.Mode(cl.GetNick(), "+B")
 		for _, ch := range b.cfg.Channels {
 			cl.Cmd.Join(ch)
 		}

--- a/internal/bots/snitch/snitch.go
+++ b/internal/bots/snitch/snitch.go
@@ -50,6 +50,10 @@ type Config struct {
 
 	// Channels is the list of channels to join on connect.
 	Channels []string
+
+	// MonitorNicks is the list of nicks to track via IRC MONITOR.
+	// Snitch will alert when a monitored nick goes offline unexpectedly.
+	MonitorNicks []string
 }
 
 func (c *Config) setDefaults() {
@@ -144,8 +148,34 @@ func (b *Bot) Start(ctx context.Context) error {
 		if b.cfg.AlertChannel != "" {
 			cl.Cmd.Join(b.cfg.AlertChannel)
 		}
+		if len(b.cfg.MonitorNicks) > 0 {
+			cl.Cmd.SendRawf("MONITOR + %s", strings.Join(b.cfg.MonitorNicks, ","))
+		}
 		if b.log != nil {
-			b.log.Info("snitch connected", "channels", b.cfg.Channels)
+			b.log.Info("snitch connected", "channels", b.cfg.Channels, "monitor", b.cfg.MonitorNicks)
+		}
+	})
+
+	// away-notify: track agents going idle or returning.
+	c.Handlers.AddBg(girc.AWAY, func(_ *girc.Client, e girc.Event) {
+		if e.Source == nil {
+			return
+		}
+		nick := e.Source.Name
+		reason := e.Last()
+		if reason != "" {
+			b.alert(fmt.Sprintf("agent away: %s (%s)", nick, reason))
+		}
+	})
+
+	c.Handlers.AddBg(girc.RPL_MONOFFLINE, func(_ *girc.Client, e girc.Event) {
+		nicks := e.Last()
+		for _, nick := range strings.Split(nicks, ",") {
+			nick = strings.TrimSpace(nick)
+			if nick == "" {
+				continue
+			}
+			b.alert(fmt.Sprintf("monitored nick offline: %s", nick))
 		}
 	})
 
@@ -203,6 +233,20 @@ func (b *Bot) Start(ctx context.Context) error {
 func (b *Bot) JoinChannel(channel string) {
 	if b.client != nil {
 		b.client.Cmd.Join(channel)
+	}
+}
+
+// MonitorAdd adds nicks to the MONITOR list at runtime.
+func (b *Bot) MonitorAdd(nicks ...string) {
+	if b.client != nil && len(nicks) > 0 {
+		b.client.Cmd.SendRawf("MONITOR + %s", strings.Join(nicks, ","))
+	}
+}
+
+// MonitorRemove removes nicks from the MONITOR list at runtime.
+func (b *Bot) MonitorRemove(nicks ...string) {
+	if b.client != nil && len(nicks) > 0 {
+		b.client.Cmd.SendRawf("MONITOR - %s", strings.Join(nicks, ","))
 	}
 }
 

--- a/internal/bots/steward/steward.go
+++ b/internal/bots/steward/steward.go
@@ -132,6 +132,7 @@ func (b *Bot) Start(ctx context.Context) error {
 	})
 
 	c.Handlers.AddBg(girc.CONNECTED, func(cl *girc.Client, _ girc.Event) {
+		cl.Cmd.Mode(cl.GetNick(), "+B")
 		for _, ch := range b.cfg.Channels {
 			cl.Cmd.Join(ch)
 		}

--- a/internal/bots/systembot/systembot.go
+++ b/internal/bots/systembot/systembot.go
@@ -93,6 +93,7 @@ func (b *Bot) Start(ctx context.Context) error {
 	})
 
 	c.Handlers.AddBg(girc.CONNECTED, func(cl *girc.Client, _ girc.Event) {
+		cl.Cmd.Mode(cl.GetNick(), "+B")
 		for _, ch := range b.channels {
 			cl.Cmd.Join(ch)
 		}

--- a/internal/bots/warden/warden.go
+++ b/internal/bots/warden/warden.go
@@ -312,7 +312,15 @@ func (b *Bot) enforce(cl *girc.Client, channel, nick string, action Action, reas
 		cl.Cmd.Notice(nick, fmt.Sprintf("warden: warning — %s in %s", reason, channel))
 	case ActionMute:
 		cl.Cmd.Notice(nick, fmt.Sprintf("warden: muted in %s — %s", channel, reason))
-		cl.Cmd.Mode(channel, "+q", nick)
+		// Use extended ban m: to mute — agent stays in channel but cannot speak.
+		mask := "m:" + nick + "!*@*"
+		cl.Cmd.Mode(channel, "+b", mask)
+		// Remove mute after cooldown so the agent can recover.
+		cs := b.channelStateFor(channel)
+		go func() {
+			time.Sleep(cs.cfg.CoolDown)
+			cl.Cmd.Mode(channel, "-b", mask)
+		}()
 	case ActionKick:
 		cl.Cmd.Kick(channel, nick, "warden: "+reason)
 	}

--- a/internal/bots/warden/warden.go
+++ b/internal/bots/warden/warden.go
@@ -201,6 +201,7 @@ func (b *Bot) Start(ctx context.Context) error {
 	})
 
 	c.Handlers.AddBg(girc.CONNECTED, func(cl *girc.Client, _ girc.Event) {
+		cl.Cmd.Mode(cl.GetNick(), "+B")
 		for _, ch := range b.initChannels {
 			cl.Cmd.Join(ch)
 		}

--- a/pkg/chathistory/chathistory.go
+++ b/pkg/chathistory/chathistory.go
@@ -1,0 +1,183 @@
+// Package chathistory provides a synchronous wrapper around the IRCv3
+// CHATHISTORY extension for use with girc clients.
+//
+// Usage:
+//
+//	fetcher := chathistory.New(client)
+//	msgs, err := fetcher.Latest(ctx, "#channel", 50)
+package chathistory
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/lrstanley/girc"
+)
+
+// Message is a single message returned by a CHATHISTORY query.
+type Message struct {
+	At      time.Time
+	Nick    string
+	Account string
+	Text    string
+	MsgID   string
+}
+
+// Fetcher sends CHATHISTORY commands and collects the batched responses.
+type Fetcher struct {
+	client *girc.Client
+
+	mu       sync.Mutex
+	batches  map[string]*batch          // batchRef → accumulator
+	waiters  map[string]chan []Message   // channel → result (one waiter per channel)
+	handlers bool
+}
+
+type batch struct {
+	channel string
+	msgs    []Message
+}
+
+// New creates a Fetcher and registers the necessary BATCH handlers on the
+// client. The client's Config.SupportedCaps should include
+// "draft/chathistory" (or "chathistory") so the capability is negotiated.
+func New(client *girc.Client) *Fetcher {
+	f := &Fetcher{
+		client:  client,
+		batches: make(map[string]*batch),
+		waiters: make(map[string]chan []Message),
+	}
+	f.registerHandlers()
+	return f
+}
+
+func (f *Fetcher) registerHandlers() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.handlers {
+		return
+	}
+	f.handlers = true
+
+	// BATCH open/close.
+	f.client.Handlers.AddBg("BATCH", func(_ *girc.Client, e girc.Event) {
+		if len(e.Params) < 1 {
+			return
+		}
+		raw := e.Params[0]
+		if strings.HasPrefix(raw, "+") {
+			ref := raw[1:]
+			if len(e.Params) >= 2 && e.Params[1] == "chathistory" {
+				ch := ""
+				if len(e.Params) >= 3 {
+					ch = e.Params[2]
+				}
+				f.mu.Lock()
+				f.batches[ref] = &batch{channel: ch}
+				f.mu.Unlock()
+			}
+		} else if strings.HasPrefix(raw, "-") {
+			ref := raw[1:]
+			f.mu.Lock()
+			b, ok := f.batches[ref]
+			if ok {
+				delete(f.batches, ref)
+				if w, wok := f.waiters[b.channel]; wok {
+					delete(f.waiters, b.channel)
+					f.mu.Unlock()
+					w <- b.msgs
+					return
+				}
+			}
+			f.mu.Unlock()
+		}
+	})
+
+	// Collect PRIVMSGs tagged with a tracked batch ref.
+	f.client.Handlers.AddBg(girc.PRIVMSG, func(_ *girc.Client, e girc.Event) {
+		batchRef, ok := e.Tags.Get("batch")
+		if !ok || batchRef == "" {
+			return
+		}
+
+		f.mu.Lock()
+		b, tracked := f.batches[batchRef]
+		if !tracked {
+			f.mu.Unlock()
+			return
+		}
+
+		nick := ""
+		if e.Source != nil {
+			nick = e.Source.Name
+		}
+		acct, _ := e.Tags.Get("account")
+		msgID, _ := e.Tags.Get("msgid")
+
+		b.msgs = append(b.msgs, Message{
+			At:      e.Timestamp,
+			Nick:    nick,
+			Account: acct,
+			Text:    e.Last(),
+			MsgID:   msgID,
+		})
+		f.mu.Unlock()
+	})
+}
+
+// Latest fetches the N most recent messages from a channel using
+// CHATHISTORY LATEST. Blocks until the server responds or ctx expires.
+func (f *Fetcher) Latest(ctx context.Context, channel string, count int) ([]Message, error) {
+	result := make(chan []Message, 1)
+
+	f.mu.Lock()
+	f.waiters[channel] = result
+	f.mu.Unlock()
+
+	if err := f.client.Cmd.SendRawf("CHATHISTORY LATEST %s * %d", channel, count); err != nil {
+		f.mu.Lock()
+		delete(f.waiters, channel)
+		f.mu.Unlock()
+		return nil, fmt.Errorf("chathistory: send: %w", err)
+	}
+
+	select {
+	case msgs := <-result:
+		return msgs, nil
+	case <-ctx.Done():
+		f.mu.Lock()
+		delete(f.waiters, channel)
+		f.mu.Unlock()
+		return nil, ctx.Err()
+	}
+}
+
+// Before fetches up to count messages before the given timestamp.
+func (f *Fetcher) Before(ctx context.Context, channel string, before time.Time, count int) ([]Message, error) {
+	result := make(chan []Message, 1)
+
+	f.mu.Lock()
+	f.waiters[channel] = result
+	f.mu.Unlock()
+
+	ts := before.UTC().Format("2006-01-02T15:04:05.000Z")
+	if err := f.client.Cmd.SendRawf("CHATHISTORY BEFORE %s timestamp=%s %d", channel, ts, count); err != nil {
+		f.mu.Lock()
+		delete(f.waiters, channel)
+		f.mu.Unlock()
+		return nil, fmt.Errorf("chathistory: send: %w", err)
+	}
+
+	select {
+	case msgs := <-result:
+		return msgs, nil
+	case <-ctx.Done():
+		f.mu.Lock()
+		delete(f.waiters, channel)
+		f.mu.Unlock()
+		return nil, ctx.Err()
+	}
+}

--- a/pkg/sessionrelay/irc.go
+++ b/pkg/sessionrelay/irc.go
@@ -136,15 +136,29 @@ func (c *ircConnector) dial(host string, port int, onJoined func()) {
 		if !c.hasChannel(target) {
 			return
 		}
+		// Prefer account-tag (IRCv3) over source nick.
 		sender := e.Source.Name
+		if acct, ok := e.Tags.Get("account"); ok && acct != "" {
+			sender = acct
+		}
 		text := strings.TrimSpace(e.Last())
+		// Fallback: parse legacy [nick] prefix from bridge bot.
 		if sender == "bridge" && strings.HasPrefix(text, "[") {
 			if end := strings.Index(text, "] "); end != -1 {
 				sender = text[1:end]
 				text = strings.TrimSpace(text[end+2:])
 			}
 		}
-		c.appendMessage(Message{At: time.Now(), Channel: target, Nick: sender, Text: text})
+		// Use server-time when available; fall back to local clock.
+		at := e.Timestamp
+		if at.IsZero() {
+			at = time.Now()
+		}
+		var msgID string
+		if id, ok := e.Tags.Get("msgid"); ok {
+			msgID = id
+		}
+		c.appendMessage(Message{At: at, Channel: target, Nick: sender, Text: text, MsgID: msgID})
 	})
 
 	c.mu.Lock()

--- a/pkg/sessionrelay/sessionrelay.go
+++ b/pkg/sessionrelay/sessionrelay.go
@@ -44,6 +44,7 @@ type Message struct {
 	Channel string
 	Nick    string
 	Text    string
+	MsgID   string
 }
 
 type Connector interface {


### PR DESCRIPTION
## Summary

Broad IRCv3 leverage pass across the codebase. Closes #119, #122, #120, #111, #108, #121, #106.

- **#119 / #122** — Bridge and relay connector use account-tag, server-time, and msgid from IRCv3 message tags
- **#120** — All 11 system bots set +B (bot) user mode on connect; INVITE auto-join was already in place
- **#111** — Warden uses extended ban `m:nick!*@*` for muting instead of +q (which is channel owner in Ergo); mute auto-expires after cooldown
- **#108** — Snitch uses MONITOR for agent presence tracking with alerts on unexpected offline events; MonitorAdd/MonitorRemove for runtime updates
- **#121** — Snitch handles away-notify for agent idle detection
- **#106** — New `pkg/chathistory` wraps IRCv3 CHATHISTORY BATCH protocol; scroll and oracle negotiate chathistory cap and prefer it over scribe store, with fallback

## Test plan

- [x] `go test ./...` — all pass
- [x] `go vet ./...` — clean
- [x] `gofmt` — clean
- [ ] Deploy with CHATHISTORY-enabled Ergo and verify scroll/oracle use server history
- [ ] Verify +B mode visible in WHOIS for all bots
- [ ] Verify warden mute uses `+b m:` (check MODE events in IRC)
- [ ] Test MONITOR alerts by disconnecting a monitored agent