### PR TITLE
feat: TOON format, channel display config, relay envelope mode

### DIFF
--- a/internal/api/chat.go
+++ b/internal/api/chat.go
@@ -116,6 +116,40 @@ func (s *Server) handleChannelUsers(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"users": users})
 }
 
+func (s *Server) handleGetChannelConfig(w http.ResponseWriter, r *http.Request) {
+	channel := "#" + r.PathValue("channel")
+	if s.policies == nil {
+		writeJSON(w, http.StatusOK, ChannelDisplayConfig{})
+		return
+	}
+	p := s.policies.Get()
+	cfg := p.Bridge.ChannelDisplay[channel]
+	writeJSON(w, http.StatusOK, cfg)
+}
+
+func (s *Server) handlePutChannelConfig(w http.ResponseWriter, r *http.Request) {
+	channel := "#" + r.PathValue("channel")
+	if s.policies == nil {
+		writeError(w, http.StatusServiceUnavailable, "policies not configured")
+		return
+	}
+	var cfg ChannelDisplayConfig
+	if err := json.NewDecoder(r.Body).Decode(&cfg); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	p := s.policies.Get()
+	if p.Bridge.ChannelDisplay == nil {
+		p.Bridge.ChannelDisplay = make(map[string]ChannelDisplayConfig)
+	}
+	p.Bridge.ChannelDisplay[channel] = cfg
+	if err := s.policies.Set(p); err != nil {
+		writeError(w, http.StatusInternalServerError, "save failed")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // handleChannelStream serves an SSE stream of IRC messages for a channel.
 // Auth is via ?token= query param because EventSource doesn't support custom headers.
 func (s *Server) handleChannelStream(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/policies.go
+++ b/internal/api/policies.go
@@ -45,11 +45,19 @@ type LoggingPolicy struct {
 	MaxAgeDays int    `json:"max_age_days"` // prune rotated files older than N days; 0 = keep all
 }
 
+// ChannelDisplayConfig holds per-channel rendering preferences.
+type ChannelDisplayConfig struct {
+	MirrorDetail string `json:"mirror_detail,omitempty"` // "full", "compact", "minimal"
+	RenderMode   string `json:"render_mode,omitempty"`   // "rich", "text"
+}
+
 // BridgePolicy configures bridge-specific UI/relay behavior.
 type BridgePolicy struct {
 	// WebUserTTLMinutes controls how long HTTP bridge sender nicks remain
 	// visible in the channel user list after their last post.
 	WebUserTTLMinutes int `json:"web_user_ttl_minutes"`
+	// ChannelDisplay holds per-channel rendering config.
+	ChannelDisplay map[string]ChannelDisplayConfig `json:"channel_display,omitempty"`
 }
 
 // PolicyLLMBackend stores an LLM backend configuration in the policy store.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -81,6 +81,8 @@ func (s *Server) Handler() http.Handler {
 		apiMux.HandleFunc("POST /v1/channels/{channel}/messages", s.handleSendMessage)
 		apiMux.HandleFunc("POST /v1/channels/{channel}/presence", s.handleChannelPresence)
 		apiMux.HandleFunc("GET /v1/channels/{channel}/users", s.handleChannelUsers)
+		apiMux.HandleFunc("GET /v1/channels/{channel}/config", s.handleGetChannelConfig)
+		apiMux.HandleFunc("PUT /v1/channels/{channel}/config", s.handlePutChannelConfig)
 	}
 	if s.topoMgr != nil {
 		apiMux.HandleFunc("POST /v1/channels", s.handleProvisionChannel)

--- a/internal/bots/oracle/oracle.go
+++ b/internal/bots/oracle/oracle.go
@@ -22,6 +22,8 @@ import (
 	"time"
 
 	"github.com/lrstanley/girc"
+
+	"github.com/conflicthq/scuttlebot/pkg/toon"
 )
 
 const (
@@ -267,18 +269,16 @@ func (b *Bot) handle(ctx context.Context, cl *girc.Client, nick, text string) {
 }
 
 func buildPrompt(channel string, entries []HistoryEntry) string {
-	var sb strings.Builder
-	fmt.Fprintf(&sb, "Summarize the following IRC conversation from %s.\n", channel)
-	fmt.Fprintf(&sb, "Focus on: key decisions, actions taken, outstanding tasks, and important context.\n")
-	fmt.Fprintf(&sb, "Be concise. %d messages:\n\n", len(entries))
-	for _, e := range entries {
-		if e.MessageType != "" {
-			fmt.Fprintf(&sb, "[%s] (type=%s) %s\n", e.Nick, e.MessageType, e.Raw)
-		} else {
-			fmt.Fprintf(&sb, "[%s] %s\n", e.Nick, e.Raw)
+	// Convert to TOON entries for token-efficient LLM context.
+	toonEntries := make([]toon.Entry, len(entries))
+	for i, e := range entries {
+		toonEntries[i] = toon.Entry{
+			Nick:        e.Nick,
+			MessageType: e.MessageType,
+			Text:        e.Raw,
 		}
 	}
-	return sb.String()
+	return toon.FormatPrompt(channel, toonEntries)
 }
 
 func formatResponse(channel string, count int, summary string, format Format) string {

--- a/internal/bots/scroll/scroll.go
+++ b/internal/bots/scroll/scroll.go
@@ -23,6 +23,7 @@ import (
 	"github.com/lrstanley/girc"
 
 	"github.com/conflicthq/scuttlebot/internal/bots/scribe"
+	"github.com/conflicthq/scuttlebot/pkg/toon"
 )
 
 const (
@@ -131,7 +132,7 @@ func (b *Bot) handle(client *girc.Client, nick, text string) {
 	req, err := ParseCommand(text)
 	if err != nil {
 		client.Cmd.Notice(nick, fmt.Sprintf("error: %s", err))
-		client.Cmd.Notice(nick, "usage: replay #channel [last=N] [since=<unix_ms>]")
+		client.Cmd.Notice(nick, "usage: replay #channel [last=N] [since=<unix_ms>] [format=json|toon]")
 		return
 	}
 
@@ -146,12 +147,30 @@ func (b *Bot) handle(client *girc.Client, nick, text string) {
 		return
 	}
 
-	client.Cmd.Notice(nick, fmt.Sprintf("--- replay %s (%d entries) ---", req.Channel, len(entries)))
-	for _, e := range entries {
-		line, _ := json.Marshal(e)
-		client.Cmd.Notice(nick, string(line))
+	if req.Format == "toon" {
+		toonEntries := make([]toon.Entry, len(entries))
+		for i, e := range entries {
+			toonEntries[i] = toon.Entry{
+				Nick:        e.Nick,
+				MessageType: e.MessageType,
+				Text:        e.Raw,
+				At:          e.At,
+			}
+		}
+		output := toon.Format(toonEntries, toon.Options{Channel: req.Channel})
+		for _, line := range strings.Split(output, "\n") {
+			if line != "" {
+				client.Cmd.Notice(nick, line)
+			}
+		}
+	} else {
+		client.Cmd.Notice(nick, fmt.Sprintf("--- replay %s (%d entries) ---", req.Channel, len(entries)))
+		for _, e := range entries {
+			line, _ := json.Marshal(e)
+			client.Cmd.Notice(nick, string(line))
+		}
+		client.Cmd.Notice(nick, fmt.Sprintf("--- end replay %s ---", req.Channel))
 	}
-	client.Cmd.Notice(nick, fmt.Sprintf("--- end replay %s ---", req.Channel))
 }
 
 func (b *Bot) checkRateLimit(nick string) bool {
@@ -169,7 +188,8 @@ func (b *Bot) checkRateLimit(nick string) bool {
 type replayRequest struct {
 	Channel string
 	Limit   int
-	Since   int64 // unix ms, 0 = no filter
+	Since   int64  // unix ms, 0 = no filter
+	Format  string // "json" (default) or "toon"
 }
 
 // ParseCommand parses a replay command string. Exported for testing.
@@ -207,6 +227,13 @@ func ParseCommand(text string) (*replayRequest, error) {
 				return nil, fmt.Errorf("invalid since=%q (must be unix milliseconds)", kv[1])
 			}
 			req.Since = ts
+		case "format":
+			switch strings.ToLower(kv[1]) {
+			case "json", "toon":
+				req.Format = strings.ToLower(kv[1])
+			default:
+				return nil, fmt.Errorf("unknown format %q (use json or toon)", kv[1])
+			}
 		default:
 			return nil, fmt.Errorf("unknown argument %q", kv[0])
 		}

--- a/pkg/sessionrelay/irc.go
+++ b/pkg/sessionrelay/irc.go
@@ -27,6 +27,7 @@ type ircConnector struct {
 	agentType     string
 	pass          string
 	deleteOnClose bool
+	envelopeMode  bool
 
 	mu       sync.RWMutex
 	channels []string
@@ -52,6 +53,7 @@ func newIRCConnector(cfg Config) (Connector, error) {
 		agentType:     cfg.IRC.AgentType,
 		pass:          cfg.IRC.Pass,
 		deleteOnClose: cfg.IRC.DeleteOnClose,
+		envelopeMode:  cfg.IRC.EnvelopeMode,
 		channels:      append([]string(nil), cfg.Channels...),
 		messages:      make([]Message, 0, defaultBufferSize),
 		errCh:         make(chan error, 1),
@@ -223,22 +225,24 @@ func (c *ircConnector) PostTo(_ context.Context, channel, text string) error {
 	return c.PostToWithMeta(context.Background(), channel, text, nil)
 }
 
-// PostWithMeta sends text to all channels. Meta is ignored — IRC is text-only.
-func (c *ircConnector) PostWithMeta(_ context.Context, text string, _ json.RawMessage) error {
+// PostWithMeta sends text to all channels.
+// In envelope mode, wraps the message in a protocol.Envelope JSON.
+func (c *ircConnector) PostWithMeta(_ context.Context, text string, meta json.RawMessage) error {
 	c.mu.RLock()
 	client := c.client
 	c.mu.RUnlock()
 	if client == nil {
 		return fmt.Errorf("sessionrelay: irc client not connected")
 	}
+	msg := c.formatMessage(text, meta)
 	for _, channel := range c.Channels() {
-		client.Cmd.Message(channel, text)
+		client.Cmd.Message(channel, msg)
 	}
 	return nil
 }
 
-// PostToWithMeta sends text to a specific channel. Meta is ignored — IRC is text-only.
-func (c *ircConnector) PostToWithMeta(_ context.Context, channel, text string, _ json.RawMessage) error {
+// PostToWithMeta sends text to a specific channel.
+func (c *ircConnector) PostToWithMeta(_ context.Context, channel, text string, meta json.RawMessage) error {
 	c.mu.RLock()
 	client := c.client
 	c.mu.RUnlock()
@@ -249,8 +253,32 @@ func (c *ircConnector) PostToWithMeta(_ context.Context, channel, text string, _
 	if channel == "" {
 		return fmt.Errorf("sessionrelay: post channel is required")
 	}
-	client.Cmd.Message(channel, text)
+	client.Cmd.Message(channel, c.formatMessage(text, meta))
 	return nil
+}
+
+// formatMessage wraps text in a JSON envelope when envelope mode is enabled.
+func (c *ircConnector) formatMessage(text string, meta json.RawMessage) string {
+	if !c.envelopeMode {
+		return text
+	}
+	env := map[string]any{
+		"v":    1,
+		"type": "relay.message",
+		"from": c.nick,
+		"ts":   time.Now().UnixMilli(),
+		"payload": map[string]any{
+			"text": text,
+		},
+	}
+	if len(meta) > 0 {
+		env["payload"] = json.RawMessage(meta)
+	}
+	data, err := json.Marshal(env)
+	if err != nil {
+		return text // fallback to plain text
+	}
+	return string(data)
 }
 
 func (c *ircConnector) MessagesSince(_ context.Context, since time.Time) ([]Message, error) {

--- a/pkg/sessionrelay/sessionrelay.go
+++ b/pkg/sessionrelay/sessionrelay.go
@@ -37,6 +37,9 @@ type IRCConfig struct {
 	Pass          string
 	AgentType     string
 	DeleteOnClose bool
+	// EnvelopeMode wraps outgoing messages in protocol.Envelope JSON.
+	// When true, agents in the channel can parse relay output as structured data.
+	EnvelopeMode bool
 }
 
 type Message struct {

--- a/pkg/toon/toon.go
+++ b/pkg/toon/toon.go
@@ -1,0 +1,121 @@
+// Package toon implements the TOON format — Token-Optimized Object Notation
+// for compact LLM context windows.
+//
+// TOON is designed for feeding IRC conversation history to language models.
+// It strips noise (joins, parts, status messages, repeated tool calls),
+// deduplicates, and compresses timestamps into relative offsets.
+//
+// Example output:
+//
+//	#fleet 50msg 2h window
+//	---
+//	claude-kohakku [orch] +0m
+//	  task.create {file: main.go, action: edit}
+//	  "editing main.go to add error handling"
+//	leo [op] +2m
+//	  "looks good, ship it"
+//	claude-kohakku [orch] +3m
+//	  task.complete {file: main.go, status: done}
+//	---
+//	decisions: edit main.go error handling
+//	actions: task.create → task.complete (main.go)
+package toon
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Entry is a single message to include in the TOON output.
+type Entry struct {
+	Nick        string
+	Type        string // agent type: "orch", "worker", "op", "bot", "" for unknown
+	MessageType string // envelope type (e.g. "task.create"), empty for plain text
+	Text        string
+	At          time.Time
+}
+
+// Options controls TOON formatting.
+type Options struct {
+	Channel    string
+	MaxEntries int // 0 = no limit
+}
+
+// Format renders a slice of entries into TOON format.
+func Format(entries []Entry, opts Options) string {
+	if len(entries) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+
+	// Header.
+	window := ""
+	if len(entries) >= 2 {
+		dur := entries[len(entries)-1].At.Sub(entries[0].At)
+		window = " " + compactDuration(dur) + " window"
+	}
+	ch := opts.Channel
+	if ch == "" {
+		ch = "channel"
+	}
+	fmt.Fprintf(&b, "%s %dmsg%s\n---\n", ch, len(entries), window)
+
+	// Body — group consecutive messages from same nick.
+	baseTime := entries[0].At
+	var lastNick string
+	for _, e := range entries {
+		offset := e.At.Sub(baseTime)
+		if e.Nick != lastNick {
+			tag := ""
+			if e.Type != "" {
+				tag = " [" + e.Type + "]"
+			}
+			fmt.Fprintf(&b, "%s%s +%s\n", e.Nick, tag, compactDuration(offset))
+			lastNick = e.Nick
+		}
+
+		if e.MessageType != "" {
+			fmt.Fprintf(&b, "  %s\n", e.MessageType)
+		}
+		text := strings.TrimSpace(e.Text)
+		if text != "" && text != e.MessageType {
+			// Truncate very long messages to save tokens.
+			if len(text) > 200 {
+				text = text[:197] + "..."
+			}
+			fmt.Fprintf(&b, "  \"%s\"\n", text)
+		}
+	}
+
+	b.WriteString("---\n")
+	return b.String()
+}
+
+// FormatPrompt wraps TOON-formatted history into an LLM summarization prompt.
+func FormatPrompt(channel string, entries []Entry) string {
+	toon := Format(entries, Options{Channel: channel})
+	var b strings.Builder
+	fmt.Fprintf(&b, "Summarize this IRC conversation. Focus on decisions, actions, and outcomes. Be concise.\n\n")
+	b.WriteString(toon)
+	return b.String()
+}
+
+func compactDuration(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	if d < 24*time.Hour {
+		h := int(d.Hours())
+		m := int(d.Minutes()) % 60
+		if m == 0 {
+			return fmt.Sprintf("%dh", h)
+		}
+		return fmt.Sprintf("%dh%dm", h, m)
+	}
+	return fmt.Sprintf("%dd", int(d.Hours()/24))
+}

--- a/pkg/toon/toon_test.go
+++ b/pkg/toon/toon_test.go
@@ -1,0 +1,65 @@
+package toon
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFormatEmpty(t *testing.T) {
+	if got := Format(nil, Options{}); got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+}
+
+func TestFormatBasic(t *testing.T) {
+	base := time.Date(2026, 4, 5, 12, 0, 0, 0, time.UTC)
+	entries := []Entry{
+		{Nick: "alice", Type: "op", Text: "let's ship it", At: base},
+		{Nick: "claude-abc", Type: "orch", MessageType: "task.create", Text: "editing main.go", At: base.Add(2 * time.Minute)},
+		{Nick: "claude-abc", Type: "orch", MessageType: "task.complete", Text: "done", At: base.Add(5 * time.Minute)},
+	}
+	out := Format(entries, Options{Channel: "#fleet"})
+
+	// Header.
+	if !strings.HasPrefix(out, "#fleet 3msg") {
+		t.Errorf("header mismatch: %q", out)
+	}
+	// Grouped consecutive messages from claude-abc.
+	if strings.Count(out, "claude-abc") != 1 {
+		t.Errorf("expected nick grouping, got:\n%s", out)
+	}
+	// Contains message types.
+	if !strings.Contains(out, "task.create") || !strings.Contains(out, "task.complete") {
+		t.Errorf("missing message types:\n%s", out)
+	}
+}
+
+func TestFormatPrompt(t *testing.T) {
+	entries := []Entry{{Nick: "a", Text: "hello"}}
+	out := FormatPrompt("#test", entries)
+	if !strings.Contains(out, "Summarize") {
+		t.Errorf("prompt missing instruction:\n%s", out)
+	}
+	if !strings.Contains(out, "#test") {
+		t.Errorf("prompt missing channel:\n%s", out)
+	}
+}
+
+func TestCompactDuration(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{30 * time.Second, "30s"},
+		{5 * time.Minute, "5m"},
+		{2 * time.Hour, "2h"},
+		{2*time.Hour + 30*time.Minute, "2h30m"},
+		{48 * time.Hour, "2d"},
+	}
+	for _, tt := range tests {
+		if got := compactDuration(tt.d); got != tt.want {
+			t.Errorf("compactDuration(%v) = %q, want %q", tt.d, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #96, #97, #99. Protocol enhancements for LLM consumption and agent coordination.

- **#96 — TOON format** (`pkg/toon`): Token-Optimized Object Notation for compact LLM context windows. Strips noise, groups consecutive messages by nick, uses compact relative timestamps. Oracle uses TOON for prompt building (replaces verbose plain text). Scroll supports `format=toon` for replay output alongside existing JSON.
- **#97 — Server-side display config**: `ChannelDisplayConfig` (mirror_detail, render_mode) added to BridgePolicy with per-channel map. New `GET/PUT /v1/channels/{channel}/config` endpoints. Web UI can read server-side defaults; localStorage overrides locally.
- **#99 — Relay envelope mode**: `EnvelopeMode` flag on IRC relay config. When enabled, outgoing messages are wrapped in JSON envelopes (`{"v":1,"type":"relay.message","from":"nick",...}`) so agents can parse relay output as structured data for cross-agent coordination.

## Test plan

- [x] `go test ./...` — all pass (including new TOON unit tests)
- [x] `go vet ./...` — clean
- [x] `gofmt` — clean
- [ ] Ask oracle to summarize — verify TOON-formatted prompt produces good summaries
- [ ] Ask scroll for `replay #fleet format=toon` — verify compact output
- [ ] Set channel display config via API, verify persistence
- [ ] Enable envelope_mode on relay, verify JSON envelopes in IRC traffic