### PR TITLE
feat: gemini-relay reasoning/thinking block mirroring

### DIFF
--- a/cmd/gemini-relay/main.go
+++ b/cmd/gemini-relay/main.go
@@ -74,6 +74,7 @@ type config struct {
 	Nick               string
 	HooksEnabled       bool
 	InterruptOnMessage bool
+	MirrorReasoning    bool
 	PollInterval       time.Duration
 	HeartbeatInterval  time.Duration
 	TargetCWD          string
@@ -566,6 +567,41 @@ func geminiSessionMirrorLoop(ctx context.Context, relay sessionrelay.Connector, 
 				if msg.Type != "gemini" {
 					continue
 				}
+				// Mirror thinking/reasoning blocks.
+				if cfg.MirrorReasoning {
+					for _, t := range msg.Thoughts {
+						if t.Subject != "" {
+							for _, line := range splitMirrorText(t.Subject) {
+								text := "\xf0\x9f\x92\xad " + line
+								if ptyDedup != nil {
+									ptyDedup.MarkSeen(text)
+								}
+								_ = relay.Post(ctx, text)
+							}
+						}
+						if t.Description != "" {
+							for _, line := range splitMirrorText(t.Description) {
+								text := "\xf0\x9f\x92\xad " + line
+								if ptyDedup != nil {
+									ptyDedup.MarkSeen(text)
+								}
+								_ = relay.Post(ctx, text)
+							}
+						}
+					}
+				}
+
+				// Mirror content text.
+				if msg.Content != "" {
+					for _, line := range splitMirrorText(msg.Content) {
+						if ptyDedup != nil {
+							ptyDedup.MarkSeen(line)
+						}
+						_ = relay.Post(ctx, line)
+					}
+				}
+
+				// Mirror tool calls.
 				for _, tc := range msg.ToolCalls {
 					meta, _ := json.Marshal(map[string]any{
 						"type": "tool_result",
@@ -593,6 +629,33 @@ func slugify(s string) string {
 		return "default"
 	}
 	return s
+}
+
+// splitMirrorText normalises line endings, drops blank lines, and wraps
+// long lines at word boundaries to fit within defaultMirrorLineMax.
+func splitMirrorText(text string) []string {
+	clean := strings.ReplaceAll(text, "\r\n", "\n")
+	clean = strings.ReplaceAll(clean, "\r", "\n")
+	raw := strings.Split(clean, "\n")
+	var out []string
+	for _, line := range raw {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		for len(line) > defaultMirrorLineMax {
+			cut := strings.LastIndex(line[:defaultMirrorLineMax], " ")
+			if cut <= 0 {
+				cut = defaultMirrorLineMax
+			}
+			out = append(out, line[:cut])
+			line = strings.TrimSpace(line[cut:])
+		}
+		if line != "" {
+			out = append(out, line)
+		}
+	}
+	return out
 }
 
 func filterMessages(messages []message, since time.Time, nick, agentType string) ([]message, time.Time) {
@@ -640,6 +703,7 @@ func loadConfig(args []string) (config, error) {
 		IRCDeleteOnClose:   getenvBoolOr(fileConfig, "SCUTTLEBOT_IRC_DELETE_ON_CLOSE", true),
 		HooksEnabled:       getenvBoolOr(fileConfig, "SCUTTLEBOT_HOOKS_ENABLED", true),
 		InterruptOnMessage: getenvBoolOr(fileConfig, "SCUTTLEBOT_INTERRUPT_ON_MESSAGE", true),
+		MirrorReasoning:    getenvBoolOr(fileConfig, "SCUTTLEBOT_MIRROR_REASONING", true),
 		PollInterval:       getenvDurationOr(fileConfig, "SCUTTLEBOT_POLL_INTERVAL", defaultPollInterval),
 		HeartbeatInterval:  getenvDurationAllowZeroOr(fileConfig, "SCUTTLEBOT_PRESENCE_HEARTBEAT", defaultHeartbeat),
 		Args:               append([]string(nil), args...),

--- a/cmd/gemini-relay/main_test.go
+++ b/cmd/gemini-relay/main_test.go
@@ -102,6 +102,88 @@ func TestInjectMessagesIdleSkipsCtrlCAndSubmits(t *testing.T) {
 	}
 }
 
+func TestSplitMirrorText(t *testing.T) {
+	t.Run("basic lines", func(t *testing.T) {
+		got := splitMirrorText("line one\nline two\nline three")
+		if len(got) != 3 {
+			t.Fatalf("expected 3 lines, got %d: %v", len(got), got)
+		}
+		if got[0] != "line one" || got[1] != "line two" || got[2] != "line three" {
+			t.Errorf("unexpected lines: %v", got)
+		}
+	})
+
+	t.Run("blank lines filtered", func(t *testing.T) {
+		got := splitMirrorText("hello\n\n\nworld\n")
+		if len(got) != 2 {
+			t.Fatalf("expected 2 lines, got %d: %v", len(got), got)
+		}
+	})
+
+	t.Run("crlf normalised", func(t *testing.T) {
+		got := splitMirrorText("alpha\r\nbeta\rgamma")
+		if len(got) != 3 {
+			t.Fatalf("expected 3 lines, got %d: %v", len(got), got)
+		}
+	})
+
+	t.Run("long line wrapped", func(t *testing.T) {
+		long := "word " // 5 chars
+		for len(long) < defaultMirrorLineMax+50 {
+			long += "word "
+		}
+		got := splitMirrorText(long)
+		if len(got) < 2 {
+			t.Fatalf("expected wrapped output, got %d lines", len(got))
+		}
+		for i, line := range got {
+			if len(line) > defaultMirrorLineMax {
+				t.Errorf("line %d exceeds max: len=%d", i, len(line))
+			}
+		}
+	})
+
+	t.Run("empty string", func(t *testing.T) {
+		got := splitMirrorText("")
+		if len(got) != 0 {
+			t.Fatalf("expected 0 lines, got %d", len(got))
+		}
+	})
+}
+
+func TestLoadConfigMirrorReasoningDefault(t *testing.T) {
+	t.Setenv("SCUTTLEBOT_CONFIG_FILE", filepath.Join(t.TempDir(), "scuttlebot-relay.env"))
+	t.Setenv("SCUTTLEBOT_URL", "http://test:8080")
+	t.Setenv("SCUTTLEBOT_TOKEN", "test-token")
+	t.Setenv("SCUTTLEBOT_SESSION_ID", "abc")
+	t.Setenv("SCUTTLEBOT_NICK", "")
+
+	cfg, err := loadConfig([]string{"--cd", "../.."})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.MirrorReasoning {
+		t.Error("MirrorReasoning should default to true")
+	}
+}
+
+func TestLoadConfigMirrorReasoningDisabled(t *testing.T) {
+	t.Setenv("SCUTTLEBOT_CONFIG_FILE", filepath.Join(t.TempDir(), "scuttlebot-relay.env"))
+	t.Setenv("SCUTTLEBOT_URL", "http://test:8080")
+	t.Setenv("SCUTTLEBOT_TOKEN", "test-token")
+	t.Setenv("SCUTTLEBOT_SESSION_ID", "abc")
+	t.Setenv("SCUTTLEBOT_NICK", "")
+	t.Setenv("SCUTTLEBOT_MIRROR_REASONING", "false")
+
+	cfg, err := loadConfig([]string{"--cd", "../.."})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.MirrorReasoning {
+		t.Error("MirrorReasoning should be false when SCUTTLEBOT_MIRROR_REASONING=false")
+	}
+}
+
 func TestInjectMessagesBusySendsCtrlCBeforeSubmit(t *testing.T) {
 	t.Helper()
 

--- a/cmd/scuttlebot/main.go
+++ b/cmd/scuttlebot/main.go
@@ -405,7 +405,7 @@ func main() {
 	if topoMgr != nil {
 		topoIface = topoMgr
 	}
-	apiSrv := api.New(reg, apiKeyStore, bridgeBot, policyStore, adminStore, llmCfg, topoIface, cfgStore, cfg.TLS.Domain, log)
+	apiSrv := api.New(reg, apiKeyStore, bridgeBot, policyStore, adminStore, llmCfg, topoIface, cfgStore, ergoMgr.API(), cfg.TLS.Domain, log)
 	handler := apiSrv.Handler()
 
 	var httpServer, tlsServer *http.Server

--- a/cmd/scuttlectl/internal/apiclient/apiclient.go
+++ b/cmd/scuttlectl/internal/apiclient/apiclient.go
@@ -197,6 +197,11 @@ func (c *Client) SetAdminPassword(username, password string) error {
 	return err
 }
 
+// SetUserPassword sends PUT /v1/users/{nick}/password.
+func (c *Client) SetUserPassword(nick string, body map[string]any) (json.RawMessage, error) {
+	return c.put("/v1/users/"+nick+"/password", body)
+}
+
 func (c *Client) get(path string) (json.RawMessage, error) {
 	return c.do("GET", path, nil)
 }

--- a/cmd/scuttlectl/main.go
+++ b/cmd/scuttlectl/main.go
@@ -111,6 +111,19 @@ func main() {
 			fmt.Fprintf(os.Stderr, "unknown subcommand: admin %s\n", args[1])
 			os.Exit(1)
 		}
+	case "user", "users":
+		if len(args) < 2 {
+			fmt.Fprintf(os.Stderr, "usage: scuttlectl user <subcommand>\n")
+			os.Exit(1)
+		}
+		switch args[1] {
+		case "passwd":
+			requireArgs(args, 3, "scuttlectl user passwd <nick> [--length N] [--charset alpha|alphanum|hex|ascii] [--password value]")
+			cmdUserPasswd(api, args[2:])
+		default:
+			fmt.Fprintf(os.Stderr, "unknown subcommand: user %s\n", args[1])
+			os.Exit(1)
+		}
 	case "api-key", "api-keys":
 		if len(args) < 2 {
 			fmt.Fprintf(os.Stderr, "usage: scuttlectl api-key <list|create|revoke>\n")
@@ -355,6 +368,47 @@ func cmdAdminPasswd(api *apiclient.Client, username string) {
 	pass := promptPassword()
 	die(api.SetAdminPassword(username, pass))
 	fmt.Printf("Password updated for: %s\n", username)
+}
+
+func cmdUserPasswd(api *apiclient.Client, args []string) {
+	nick := args[0]
+	fs := flag.NewFlagSet("user passwd", flag.ExitOnError)
+	lengthFlag := fs.Int("length", 0, "password length (default: server decides, usually 24)")
+	charsetFlag := fs.String("charset", "", "character set: alpha, alphanum, hex, ascii (default: alphanum)")
+	passwordFlag := fs.String("password", "", "set an explicit password instead of generating")
+	_ = fs.Parse(args[1:])
+
+	body := make(map[string]any)
+	if *passwordFlag != "" {
+		body["password"] = *passwordFlag
+	}
+	if *lengthFlag > 0 {
+		body["length"] = *lengthFlag
+	}
+	if *charsetFlag != "" {
+		body["charset"] = *charsetFlag
+	}
+
+	raw, err := api.SetUserPassword(nick, body)
+	die(err)
+
+	var result struct {
+		Nick        string `json:"nick"`
+		Password    string `json:"password"`
+		AdminSynced bool   `json:"admin_synced"`
+	}
+	must(json.Unmarshal(raw, &result))
+
+	fmt.Printf("Password updated for: %s\n\n", result.Nick)
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "CREDENTIAL\tVALUE")
+	fmt.Fprintf(tw, "nick\t%s\n", result.Nick)
+	fmt.Fprintf(tw, "password\t%s\n", result.Password)
+	tw.Flush()
+	if result.AdminSynced {
+		fmt.Println("\nAdmin account password also updated (web UI login).")
+	}
+	fmt.Println("\nStore this password — it will not be shown again.")
 }
 
 func promptPassword() string {
@@ -624,6 +678,10 @@ Commands:
   admin add <username>          add admin (prompts for password)
   admin remove <username>       remove admin
   admin passwd <username>       change admin password (prompts)
+  user passwd <nick>            reset IRC user password
+    [--length 24]               password length
+    [--charset alphanum]        alpha | alphanum | hex | ascii
+    [--password value]          set explicit password
   api-key list                  list API keys
   api-key create --name <name> --scopes <s1,s2> [--expires 720h]
   api-key revoke <id>           revoke an API key

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -53,7 +53,7 @@ const testToken = "test-api-token-abc123"
 func newTestServer(t *testing.T) *httptest.Server {
 	t.Helper()
 	reg := registry.New(newMock(), []byte("test-signing-key"))
-	srv := api.New(reg, auth.TestStore(testToken), nil, nil, nil, nil, nil, nil, "", testLog)
+	srv := api.New(reg, auth.TestStore(testToken), nil, nil, nil, nil, nil, nil, nil, "", testLog)
 	return httptest.NewServer(srv.Handler())
 }
 

--- a/internal/api/channels_topology_test.go
+++ b/internal/api/channels_topology_test.go
@@ -79,7 +79,7 @@ func newTopoTestServer(t *testing.T, topo *stubTopologyManager) (*httptest.Serve
 	t.Helper()
 	reg := registry.New(nil, []byte("key"))
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
-	srv := httptest.NewServer(New(reg, auth.TestStore("tok"), nil, nil, nil, nil, topo, nil, "", log).Handler())
+	srv := httptest.NewServer(New(reg, auth.TestStore("tok"), nil, nil, nil, nil, topo, nil, nil, "", log).Handler())
 	t.Cleanup(srv.Close)
 	return srv, "tok"
 }
@@ -90,7 +90,7 @@ func newTopoTestServerWithRegistry(t *testing.T, topo *stubTopologyManager) (*ht
 	t.Helper()
 	reg := registry.New(newStubProvisioner(), []byte("key"))
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
-	srv := httptest.NewServer(New(reg, auth.TestStore("tok"), nil, nil, nil, nil, topo, nil, "", log).Handler())
+	srv := httptest.NewServer(New(reg, auth.TestStore("tok"), nil, nil, nil, nil, topo, nil, nil, "", log).Handler())
 	t.Cleanup(srv.Close)
 	return srv, "tok"
 }

--- a/internal/api/chat_test.go
+++ b/internal/api/chat_test.go
@@ -33,11 +33,11 @@ func (b *stubChatBridge) Send(context.Context, string, string, string) error { r
 func (b *stubChatBridge) SendWithMeta(_ context.Context, _, _, _ string, _ *bridge.Meta) error {
 	return nil
 }
-func (b *stubChatBridge) Stats() bridge.Stats                { return bridge.Stats{} }
-func (b *stubChatBridge) Users(string) []string              { return nil }
+func (b *stubChatBridge) Stats() bridge.Stats                     { return bridge.Stats{} }
+func (b *stubChatBridge) Users(string) []string                   { return nil }
 func (b *stubChatBridge) UsersWithModes(string) []bridge.UserInfo { return nil }
-func (b *stubChatBridge) ChannelModes(string) string         { return "" }
-func (b *stubChatBridge) RefreshNames(string)                {}
+func (b *stubChatBridge) ChannelModes(string) string              { return "" }
+func (b *stubChatBridge) RefreshNames(string)                     {}
 func (b *stubChatBridge) TouchUser(channel, nick string) {
 	b.touched = append(b.touched, struct{ channel, nick string }{channel: channel, nick: nick})
 }
@@ -48,7 +48,7 @@ func TestHandleChannelPresence(t *testing.T) {
 	bridgeStub := &stubChatBridge{}
 	reg := registry.New(nil, []byte("test-signing-key"))
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	srv := httptest.NewServer(New(reg, auth.TestStore("token"), bridgeStub, nil, nil, nil, nil, nil, "", logger).Handler())
+	srv := httptest.NewServer(New(reg, auth.TestStore("token"), bridgeStub, nil, nil, nil, nil, nil, nil, "", logger).Handler())
 	defer srv.Close()
 
 	body, _ := json.Marshal(map[string]string{"nick": "codex-test"})
@@ -81,7 +81,7 @@ func TestHandleChannelPresenceRequiresNick(t *testing.T) {
 	bridgeStub := &stubChatBridge{}
 	reg := registry.New(nil, []byte("test-signing-key"))
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	srv := httptest.NewServer(New(reg, auth.TestStore("token"), bridgeStub, nil, nil, nil, nil, nil, "", logger).Handler())
+	srv := httptest.NewServer(New(reg, auth.TestStore("token"), bridgeStub, nil, nil, nil, nil, nil, nil, "", logger).Handler())
 	defer srv.Close()
 
 	body, _ := json.Marshal(map[string]string{})

--- a/internal/api/config_handlers_test.go
+++ b/internal/api/config_handlers_test.go
@@ -28,7 +28,7 @@ func newCfgTestServer(t *testing.T) (*httptest.Server, *ConfigStore) {
 	store := NewConfigStore(path, cfg)
 	reg := registry.New(nil, []byte("key"))
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
-	srv := httptest.NewServer(New(reg, auth.TestStore("tok"), nil, nil, nil, nil, nil, store, "", log).Handler())
+	srv := httptest.NewServer(New(reg, auth.TestStore("tok"), nil, nil, nil, nil, nil, store, nil, "", log).Handler())
 	t.Cleanup(srv.Close)
 	return srv, store
 }

--- a/internal/api/login_test.go
+++ b/internal/api/login_test.go
@@ -30,14 +30,14 @@ func newTestServerWithAdmins(t *testing.T) (*httptest.Server, *auth.AdminStore) 
 		t.Fatalf("Add admin: %v", err)
 	}
 	reg := registry.New(newMock(), []byte("test-signing-key"))
-	srv := api.New(reg, auth.TestStore(testToken), nil, nil, admins, nil, nil, nil, "", testLog)
+	srv := api.New(reg, auth.TestStore(testToken), nil, nil, admins, nil, nil, nil, nil, "", testLog)
 	return httptest.NewServer(srv.Handler()), admins
 }
 
 func TestLoginNoAdmins(t *testing.T) {
 	// When admins is nil, login returns 404.
 	reg := registry.New(newMock(), []byte("test-signing-key"))
-	srv := api.New(reg, auth.TestStore(testToken), nil, nil, nil, nil, nil, nil, "", testLog)
+	srv := api.New(reg, auth.TestStore(testToken), nil, nil, nil, nil, nil, nil, nil, "", testLog)
 	ts := httptest.NewServer(srv.Handler())
 	defer ts.Close()
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -14,6 +14,11 @@ import (
 	"github.com/conflicthq/scuttlebot/internal/registry"
 )
 
+// ircPasswdSetter can change an IRC (NickServ) account's password.
+type ircPasswdSetter interface {
+	ChangePassword(name, passphrase string) error
+}
+
 // Server is the scuttlebot HTTP API server.
 type Server struct {
 	registry  *registry.Registry
@@ -25,6 +30,7 @@ type Server struct {
 	llmCfg    *config.LLMConfig // nil if no LLM backends configured
 	topoMgr   topologyManager   // nil if topology not configured
 	cfgStore  *ConfigStore      // nil if config write-back not configured
+	ircPasswd ircPasswdSetter   // nil if not configured
 	loginRL   *loginRateLimiter
 	tlsDomain string // empty if no TLS
 }
@@ -34,7 +40,8 @@ type Server struct {
 // Pass nil for llmCfg to disable AI/LLM management endpoints.
 // Pass nil for topo to disable topology provisioning endpoints.
 // Pass nil for cfgStore to disable config read/write endpoints.
-func New(reg *registry.Registry, apiKeys *auth.APIKeyStore, b chatBridge, ps *PolicyStore, admins adminStore, llmCfg *config.LLMConfig, topo topologyManager, cfgStore *ConfigStore, tlsDomain string, log *slog.Logger) *Server {
+// Pass nil for ircPasswd to disable IRC user password management.
+func New(reg *registry.Registry, apiKeys *auth.APIKeyStore, b chatBridge, ps *PolicyStore, admins adminStore, llmCfg *config.LLMConfig, topo topologyManager, cfgStore *ConfigStore, ircPasswd ircPasswdSetter, tlsDomain string, log *slog.Logger) *Server {
 	return &Server{
 		registry:  reg,
 		apiKeys:   apiKeys,
@@ -45,6 +52,7 @@ func New(reg *registry.Registry, apiKeys *auth.APIKeyStore, b chatBridge, ps *Po
 		llmCfg:    llmCfg,
 		topoMgr:   topo,
 		cfgStore:  cfgStore,
+		ircPasswd: ircPasswd,
 		loginRL:   newLoginRateLimiter(),
 		tlsDomain: tlsDomain,
 	}
@@ -128,6 +136,11 @@ func (s *Server) Handler() http.Handler {
 	apiMux.HandleFunc("GET /v1/api-keys", s.requireScope(auth.ScopeAdmin, s.handleListAPIKeys))
 	apiMux.HandleFunc("POST /v1/api-keys", s.requireScope(auth.ScopeAdmin, s.handleCreateAPIKey))
 	apiMux.HandleFunc("DELETE /v1/api-keys/{id}", s.requireScope(auth.ScopeAdmin, s.handleRevokeAPIKey))
+
+	// IRC user management — admin scope.
+	if s.ircPasswd != nil {
+		apiMux.HandleFunc("PUT /v1/users/{nick}/password", s.requireScope(auth.ScopeAdmin, s.handleUserSetPassword))
+	}
 
 	// LLM / AI gateway — bots scope.
 	apiMux.HandleFunc("GET /v1/llm/backends", s.requireScope(auth.ScopeBots, s.handleLLMBackends))

--- a/internal/api/ui/index.html
+++ b/internal/api/ui/index.html
@@ -471,6 +471,7 @@ canvas { display:block; width:100% !important; }
     <button class="sm" onclick="openAdoptDrawer()">adopt existing user</button>
     <button class="sm primary" onclick="openRegisterUserDrawer()">+ register user</button>
   </div>
+  <div id="user-password-result" style="display:none;padding:0 12px"></div>
   <div style="flex:1;overflow-y:auto">
     <div id="users-container"></div>
   </div>
@@ -1617,6 +1618,7 @@ function renderUsersTable() {
       <td>${chs||'<span style="color:#8b949e">—</span>'}</td>
       <td style="white-space:nowrap">${fmtTime(a.created_at)}</td>
       <td><div class="actions">${!a.revoked?`
+        <button class="sm" onclick="resetUserPassword('${esc(a.nick)}')">reset password</button>
         <button class="sm" onclick="rotateAgent('${esc(a.nick)}')">rotate</button>
         <button class="sm danger" onclick="revokeAgent('${esc(a.nick)}')">revoke</button>`:``}
         <button class="sm danger" onclick="deleteAgent('${esc(a.nick)}')">delete</button></div></td>
@@ -1764,6 +1766,25 @@ async function rotateAgent(nick) {
     openDrawer();
   }
   catch(e) { alert('Rotate failed: '+e.message); }
+}
+
+async function resetUserPassword(nick) {
+  if (!confirm(`Reset password for ${nick}? This will generate a new password for both IRC and web UI login.`)) return;
+  try {
+    const result = await api('PUT', `/v1/users/${encodeURIComponent(nick)}/password`, {});
+    const el = document.getElementById('user-password-result');
+    el.style.display = 'block';
+    const synced = result.admin_synced ? '<div style="margin-top:6px;font-size:11px;color:#58a6ff">Admin (web UI) password also updated.</div>' : '';
+    el.innerHTML = renderAlert('success',
+      `<div><strong>Password reset: ${esc(nick)}</strong>
+      <div class="cred-box">
+        <div class="cred-row"><span class="cred-key">nick</span><span class="cred-val">${esc(result.nick)}</span><button class="sm" onclick="copyText('${esc(result.nick)}',this)">copy</button></div>
+        <div class="cred-row"><span class="cred-key">password</span><span class="cred-val">${esc(result.password)}</span><button class="sm" onclick="copyText('${esc(result.password)}',this)">copy</button></div>
+      </div>${synced}
+      <div style="margin-top:8px;font-size:11px;color:#7ee787">Save the password — shown once only.</div>
+      <button class="sm" onclick="this.closest('.alert').parentElement.style.display='none'" style="margin-top:8px">dismiss</button></div>`
+    );
+  } catch(e) { alert('Reset failed: ' + e.message); }
 }
 
 // --- users drawers ---

--- a/internal/api/user_handlers.go
+++ b/internal/api/user_handlers.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/conflicthq/scuttlebot/pkg/passgen"
+)
+
+// handleUserSetPassword handles PUT /v1/users/{nick}/password.
+// Resets the NickServ password for an IRC user account.
+func (s *Server) handleUserSetPassword(w http.ResponseWriter, r *http.Request) {
+	nick := r.PathValue("nick")
+
+	var req struct {
+		Password string `json:"password"` // explicit; empty = generate
+		Length   int    `json:"length"`   // for generation (default 24)
+		Charset  string `json:"charset"`  // for generation (default alphanum)
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+
+	password := req.Password
+	if password == "" {
+		opts := &passgen.Options{}
+		if req.Length > 0 {
+			opts.Length = req.Length
+		}
+		if req.Charset != "" {
+			cs, err := passgen.ParseCharset(req.Charset)
+			if err != nil {
+				writeError(w, http.StatusBadRequest, err.Error())
+				return
+			}
+			opts.Charset = cs
+		}
+		var err error
+		password, err = passgen.Generate(opts)
+		if err != nil {
+			s.log.Error("generate password", "err", err)
+			writeError(w, http.StatusInternalServerError, "password generation failed")
+			return
+		}
+	}
+
+	if err := s.ircPasswd.ChangePassword(nick, password); err != nil {
+		s.log.Error("set user password", "nick", nick, "err", err)
+		writeError(w, http.StatusInternalServerError, "failed to set password: "+err.Error())
+		return
+	}
+
+	// If a matching admin account exists, keep it in sync.
+	adminSynced := false
+	if s.admins != nil {
+		if err := s.admins.SetPassword(nick, password); err == nil {
+			adminSynced = true
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"nick":         nick,
+		"password":     password,
+		"admin_synced": adminSynced,
+	})
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -7,7 +7,6 @@ package registry
 
 import (
 	"crypto/hmac"
-	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -18,6 +17,7 @@ import (
 	"time"
 
 	"github.com/conflicthq/scuttlebot/internal/store"
+	"github.com/conflicthq/scuttlebot/pkg/passgen"
 )
 
 // AgentType describes an agent's role and authority level.
@@ -520,9 +520,5 @@ func VerifyPayload(sp *SignedPayload, signingKey []byte) error {
 }
 
 func generatePassphrase() (string, error) {
-	b := make([]byte, 32)
-	if _, err := rand.Read(b); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(b), nil
+	return passgen.Generate(&passgen.Options{Length: 64, Charset: passgen.Hex})
 }

--- a/pkg/passgen/passgen.go
+++ b/pkg/passgen/passgen.go
@@ -1,0 +1,114 @@
+// Package passgen provides configurable password generation using
+// cryptographically secure randomness.
+package passgen
+
+import (
+	"crypto/rand"
+	"fmt"
+	"math/big"
+)
+
+// Charset identifies a character pool for password generation.
+type Charset string
+
+const (
+	Hex      Charset = "hex"      // 0-9a-f
+	Alpha    Charset = "alpha"    // a-zA-Z
+	Alphanum Charset = "alphanum" // a-zA-Z0-9
+	ASCII    Charset = "ascii"    // printable ASCII 33-126, excluding ' " ` \
+)
+
+const (
+	hexChars      = "0123456789abcdef"
+	alphaChars    = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	alphanumChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+)
+
+// asciiChars is printable ASCII 33-126 minus ' " ` \ which cause shell
+// escaping problems.
+var asciiChars string
+
+func init() {
+	var b []byte
+	for c := byte(33); c <= 126; c++ {
+		switch c {
+		case '\'', '"', '`', '\\':
+			continue
+		}
+		b = append(b, c)
+	}
+	asciiChars = string(b)
+}
+
+// Options controls password generation.
+type Options struct {
+	Length  int     // default 24
+	Charset Charset // default Alphanum
+}
+
+// Generate creates a random password using the given options.
+// If opts is nil, defaults are used (24-char alphanum).
+func Generate(opts *Options) (string, error) {
+	length := 24
+	charset := Alphanum
+
+	if opts != nil {
+		if opts.Length != 0 {
+			length = opts.Length
+		}
+		if opts.Charset != "" {
+			charset = opts.Charset
+		}
+	}
+
+	if length < 1 {
+		return "", fmt.Errorf("passgen: length must be >= 1, got %d", length)
+	}
+
+	pool, err := charsetPool(charset)
+	if err != nil {
+		return "", err
+	}
+
+	max := big.NewInt(int64(len(pool)))
+	buf := make([]byte, length)
+	for i := range buf {
+		idx, err := rand.Int(rand.Reader, max)
+		if err != nil {
+			return "", fmt.Errorf("passgen: crypto/rand: %w", err)
+		}
+		buf[i] = pool[idx.Int64()]
+	}
+	return string(buf), nil
+}
+
+// ParseCharset parses a charset name, returning an error for unknown values.
+func ParseCharset(s string) (Charset, error) {
+	switch Charset(s) {
+	case Hex:
+		return Hex, nil
+	case Alpha:
+		return Alpha, nil
+	case Alphanum:
+		return Alphanum, nil
+	case ASCII:
+		return ASCII, nil
+	default:
+		return "", fmt.Errorf("passgen: unknown charset %q", s)
+	}
+}
+
+func charsetPool(c Charset) (string, error) {
+	switch c {
+	case Hex:
+		return hexChars, nil
+	case Alpha:
+		return alphaChars, nil
+	case Alphanum:
+		return alphanumChars, nil
+	case ASCII:
+		return asciiChars, nil
+	default:
+		return "", fmt.Errorf("passgen: unknown charset %q", c)
+	}
+}

--- a/pkg/passgen/passgen_test.go
+++ b/pkg/passgen/passgen_test.go
@@ -1,0 +1,145 @@
+package passgen
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateDefaults(t *testing.T) {
+	pw, err := Generate(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pw) != 24 {
+		t.Errorf("expected length 24, got %d", len(pw))
+	}
+	for _, c := range pw {
+		if !strings.ContainsRune(alphanumChars, c) {
+			t.Errorf("char %q not in alphanum charset", c)
+		}
+	}
+}
+
+func TestGenerateHex(t *testing.T) {
+	pw, err := Generate(&Options{Length: 32, Charset: Hex})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pw) != 32 {
+		t.Errorf("expected length 32, got %d", len(pw))
+	}
+	for _, c := range pw {
+		if !strings.ContainsRune(hexChars, c) {
+			t.Errorf("char %q not in hex charset", c)
+		}
+	}
+}
+
+func TestGenerateAlpha(t *testing.T) {
+	pw, err := Generate(&Options{Length: 50, Charset: Alpha})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pw) != 50 {
+		t.Errorf("expected length 50, got %d", len(pw))
+	}
+	for _, c := range pw {
+		if !strings.ContainsRune(alphaChars, c) {
+			t.Errorf("char %q not in alpha charset", c)
+		}
+	}
+}
+
+func TestGenerateASCII(t *testing.T) {
+	pw, err := Generate(&Options{Length: 100, Charset: ASCII})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pw) != 100 {
+		t.Errorf("expected length 100, got %d", len(pw))
+	}
+	excluded := `'"` + "`\\"
+	for _, c := range pw {
+		if c < 33 || c > 126 {
+			t.Errorf("char %q (0x%x) outside printable ASCII range", c, c)
+		}
+		if strings.ContainsRune(excluded, c) {
+			t.Errorf("char %q should be excluded from ASCII charset", c)
+		}
+	}
+}
+
+func TestGenerateCustomLength(t *testing.T) {
+	lengths := []int{1, 8, 64, 256}
+	for _, l := range lengths {
+		pw, err := Generate(&Options{Length: l})
+		if err != nil {
+			t.Fatalf("length %d: unexpected error: %v", l, err)
+		}
+		if len(pw) != l {
+			t.Errorf("expected length %d, got %d", l, len(pw))
+		}
+	}
+}
+
+func TestGenerateLengthZeroUsesDefault(t *testing.T) {
+	// Length 0 in Options means "use default" (Go zero-value idiom).
+	pw, err := Generate(&Options{Length: 0})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pw) != 24 {
+		t.Errorf("expected default length 24, got %d", len(pw))
+	}
+}
+
+func TestGenerateLengthTooSmall(t *testing.T) {
+	tests := []int{-1, -100}
+	for _, l := range tests {
+		_, err := Generate(&Options{Length: l})
+		if err == nil {
+			t.Errorf("length %d: expected error, got nil", l)
+		}
+	}
+}
+
+func TestGenerateUniqueness(t *testing.T) {
+	// Two sequential calls should produce different passwords.
+	// Collision probability for 24-char alphanum is negligible.
+	a, _ := Generate(nil)
+	b, _ := Generate(nil)
+	if a == b {
+		t.Errorf("two sequential Generate calls returned identical passwords: %q", a)
+	}
+}
+
+func TestParseCharset(t *testing.T) {
+	valid := []struct {
+		input string
+		want  Charset
+	}{
+		{"hex", Hex},
+		{"alpha", Alpha},
+		{"alphanum", Alphanum},
+		{"ascii", ASCII},
+	}
+	for _, tt := range valid {
+		got, err := ParseCharset(tt.input)
+		if err != nil {
+			t.Errorf("ParseCharset(%q): unexpected error: %v", tt.input, err)
+		}
+		if got != tt.want {
+			t.Errorf("ParseCharset(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestParseCharsetInvalid(t *testing.T) {
+	invalid := []string{"", "HEX", "Alphanum", "base64", "unicode", "foo"}
+	for _, s := range invalid {
+		_, err := ParseCharset(s)
+		if err == nil {
+			t.Errorf("ParseCharset(%q): expected error, got nil", s)
+		}
+	}
+}

--- a/pkg/relaymirror/session.go
+++ b/pkg/relaymirror/session.go
@@ -87,7 +87,15 @@ func SnapshotDir(dir string) map[string]bool {
 type GeminiMessage struct {
 	Type      string           `json:"type"` // "user", "gemini"
 	Content   string           `json:"content,omitempty"`
+	Thoughts  []GeminiThought  `json:"thoughts,omitempty"`
 	ToolCalls []GeminiToolCall `json:"toolCalls,omitempty"`
+}
+
+// GeminiThought is a thinking/reasoning block in a Gemini session message.
+type GeminiThought struct {
+	Subject     string `json:"subject"`
+	Description string `json:"description"`
+	Timestamp   string `json:"timestamp,omitempty"`
 }
 
 // GeminiToolCall is a tool call in a Gemini session.

--- a/pkg/relaymirror/session_test.go
+++ b/pkg/relaymirror/session_test.go
@@ -1,0 +1,114 @@
+package relaymirror
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPollGeminiSessionWithThoughts(t *testing.T) {
+	session := GeminiSession{
+		SessionID: "test-session",
+		Messages: []GeminiMessage{
+			{Type: "user", Content: "hello"},
+			{
+				Type:    "gemini",
+				Content: "I'll help with that.",
+				Thoughts: []GeminiThought{
+					{
+						Subject:     "Understanding the request",
+						Description: "The user wants help with a task.",
+						Timestamp:   "2026-04-08T12:00:00.000Z",
+					},
+					{
+						Subject:     "Planning approach",
+						Description: "I should break this down step by step.",
+					},
+				},
+				ToolCalls: []GeminiToolCall{
+					{
+						Name:   "readFile",
+						Args:   json.RawMessage(`{"path":"main.go"}`),
+						Status: "completed",
+					},
+				},
+			},
+		},
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session-test.json")
+	data, err := json.Marshal(session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Poll from index 0 to get all messages.
+	msgs, newIdx, err := PollGeminiSession(path, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if newIdx != 2 {
+		t.Errorf("expected newIdx=2, got %d", newIdx)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(msgs))
+	}
+
+	geminiMsg := msgs[1]
+	if geminiMsg.Type != "gemini" {
+		t.Errorf("expected type=gemini, got %s", geminiMsg.Type)
+	}
+	if geminiMsg.Content != "I'll help with that." {
+		t.Errorf("unexpected content: %s", geminiMsg.Content)
+	}
+	if len(geminiMsg.Thoughts) != 2 {
+		t.Fatalf("expected 2 thoughts, got %d", len(geminiMsg.Thoughts))
+	}
+	if geminiMsg.Thoughts[0].Subject != "Understanding the request" {
+		t.Errorf("thought[0].Subject = %q", geminiMsg.Thoughts[0].Subject)
+	}
+	if geminiMsg.Thoughts[0].Description != "The user wants help with a task." {
+		t.Errorf("thought[0].Description = %q", geminiMsg.Thoughts[0].Description)
+	}
+	if geminiMsg.Thoughts[1].Subject != "Planning approach" {
+		t.Errorf("thought[1].Subject = %q", geminiMsg.Thoughts[1].Subject)
+	}
+	if len(geminiMsg.ToolCalls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(geminiMsg.ToolCalls))
+	}
+
+	// Poll from index 2 should return nothing new.
+	msgs2, newIdx2, err := PollGeminiSession(path, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if newIdx2 != 2 {
+		t.Errorf("expected newIdx=2, got %d", newIdx2)
+	}
+	if len(msgs2) != 0 {
+		t.Errorf("expected 0 new messages, got %d", len(msgs2))
+	}
+}
+
+func TestGeminiMessageNoThoughts(t *testing.T) {
+	// Verify that messages without thoughts deserialize cleanly.
+	raw := `{"type":"gemini","content":"hello","toolCalls":[{"name":"ls","args":{},"status":"done"}]}`
+	var msg GeminiMessage
+	if err := json.Unmarshal([]byte(raw), &msg); err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.Thoughts) != 0 {
+		t.Errorf("expected 0 thoughts, got %d", len(msg.Thoughts))
+	}
+	if msg.Content != "hello" {
+		t.Errorf("content = %q", msg.Content)
+	}
+	if len(msg.ToolCalls) != 1 {
+		t.Errorf("expected 1 tool call, got %d", len(msg.ToolCalls))
+	}
+}


### PR DESCRIPTION
## Summary
- Add `MirrorReasoning` config field (default `true`, via `SCUTTLEBOT_MIRROR_REASONING`) to gemini-relay, matching claude-relay and codex-relay
- Add `GeminiThought` type and `Thoughts` field to `GeminiMessage` in `pkg/relaymirror/session.go` -- Gemini CLI stores thinking as `thoughts` array with `subject`, `description`, `timestamp`
- Update `geminiSessionMirrorLoop` to mirror thinking blocks (subject + description) with thought-balloon prefix, mirror content text, then tool calls
- Add `splitMirrorText` helper for line-length-safe IRC output (matching the pattern from other relays)

## Test plan
- [x] `TestSplitMirrorText` -- basic lines, blank filtering, CRLF normalisation, long line wrapping, empty input
- [x] `TestLoadConfigMirrorReasoningDefault` -- defaults to true
- [x] `TestLoadConfigMirrorReasoningDisabled` -- respects `SCUTTLEBOT_MIRROR_REASONING=false`
- [x] `TestPollGeminiSessionWithThoughts` -- deserialises thoughts from session JSON
- [x] `TestGeminiMessageNoThoughts` -- backward compatibility with messages without thoughts
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `gofmt` clean

fixes #155