### PR TITLE
fix: migrate Codex relay hooks feature flag

### DIFF
--- a/skills/openai-relay/FLEET.md
+++ b/skills/openai-relay/FLEET.md
@@ -114,7 +114,7 @@ The installer is intentionally narrow. It:
 - copies the tracked hook scripts into `~/.codex/hooks/`
 - builds and installs `codex-relay` into `~/.local/bin/`
 - merges required hook entries into `~/.codex/hooks.json`
-- ensures `features.codex_hooks = true` in `~/.codex/config.toml`
+- ensures `features.hooks = true` in `~/.codex/config.toml`
 - writes `SCUTTLEBOT_*` settings into `~/.config/scuttlebot-relay.env`
 - defaults IRC auth to auto-registration by removing any stale `SCUTTLEBOT_IRC_PASS`
 - keeps one backup copy as `*.bak` before overwriting an existing installed file

--- a/skills/openai-relay/SKILL.md
+++ b/skills/openai-relay/SKILL.md
@@ -61,7 +61,7 @@ go build -o ~/.local/bin/codex-relay ./cmd/codex-relay
 chmod +x ~/.codex/hooks/scuttlebot-post.sh ~/.codex/hooks/scuttlebot-check.sh ~/.local/bin/codex-relay
 ```
 
-Configure `~/.codex/hooks.json` and enable `features.codex_hooks = true`, then:
+Configure `~/.codex/hooks.json` and enable `features.hooks = true`, then:
 
 ```bash
 ~/.local/bin/codex-relay
@@ -190,7 +190,7 @@ Config in `~/.codex/hooks.json`:
 Enable the feature in `~/.codex/config.toml`:
 ```toml
 [features]
-codex_hooks = true
+hooks = true
 ```
 
 Required env:

--- a/skills/openai-relay/hooks/README.md
+++ b/skills/openai-relay/hooks/README.md
@@ -178,7 +178,7 @@ Enable the feature in `~/.codex/config.toml`:
 
 ```toml
 [features]
-codex_hooks = true
+hooks = true
 ```
 
 Install the compiled broker if you want startup/offline presence plus continuous
@@ -314,7 +314,7 @@ Expected output:
 - For fleet launch instructions, see [`../FLEET.md`](../FLEET.md).
 - They are safe to keep in the repo and copy into home hook directories.
 - Do not hardcode bearer tokens into the scripts.
-- Restart Codex after enabling `codex_hooks` or changing `~/.codex/hooks.json`.
+- Restart Codex after enabling `hooks` or changing `~/.codex/hooks.json`.
 - If you need a fixed nick for a long-lived session, set `SCUTTLEBOT_NICK`.
 - The broker is the right place for session-start/session-stop presence because
   Codex hooks only fire around tool events.

--- a/skills/openai-relay/install.md
+++ b/skills/openai-relay/install.md
@@ -63,7 +63,7 @@ This installer:
 - copies the tracked hook scripts into `~/.codex/hooks/`
 - builds and installs `codex-relay` into `~/.local/bin/`
 - merges the required entries into `~/.codex/hooks.json`
-- enables `features.codex_hooks = true` in `~/.codex/config.toml`
+- enables `features.hooks = true` in `~/.codex/config.toml`
 - writes or updates `~/.config/scuttlebot-relay.env`
 - defaults IRC auth to auto-registration by removing any stale `SCUTTLEBOT_IRC_PASS`
 
@@ -172,7 +172,7 @@ Enable hooks in `~/.codex/config.toml`:
 
 ```toml
 [features]
-codex_hooks = true
+hooks = true
 ```
 
 Keep shared relay settings in `~/.config/scuttlebot-relay.env`:

--- a/skills/openai-relay/scripts/install-codex-relay.sh
+++ b/skills/openai-relay/scripts/install-codex-relay.sh
@@ -264,13 +264,13 @@ remove_env_var() {
   mv "${file}.tmp" "$file"
 }
 
-ensure_codex_hooks_feature() {
+ensure_hooks_feature() {
   local file="$1"
   local tmp="${file}.tmp"
   if [ ! -f "$file" ]; then
     cat > "$tmp" <<'EOF'
 [features]
-codex_hooks = true
+hooks = true
 EOF
     mv "$tmp" "$file"
     return
@@ -280,7 +280,7 @@ EOF
     BEGIN {
       in_features = 0
       features_seen = 0
-      codex_hooks_set = 0
+      hooks_set = 0
     }
     /^\[features\][[:space:]]*$/ {
       print
@@ -289,19 +289,19 @@ EOF
       next
     }
     /^\[/ {
-      if (in_features && !codex_hooks_set) {
-        print "codex_hooks = true"
-        codex_hooks_set = 1
+      if (in_features && !hooks_set) {
+        print "hooks = true"
+        hooks_set = 1
       }
       in_features = 0
       print
       next
     }
     {
-      if (in_features && $0 ~ /^[[:space:]]*codex_hooks[[:space:]]*=/) {
-        if (!codex_hooks_set) {
-          print "codex_hooks = true"
-          codex_hooks_set = 1
+      if (in_features && $0 ~ /^[[:space:]]*(codex_hooks|hooks)[[:space:]]*=/) {
+        if (!hooks_set) {
+          print "hooks = true"
+          hooks_set = 1
         }
         next
       }
@@ -313,9 +313,9 @@ EOF
           print ""
         }
         print "[features]"
-        print "codex_hooks = true"
-      } else if (in_features && !codex_hooks_set) {
-        print "codex_hooks = true"
+        print "hooks = true"
+      } else if (in_features && !hooks_set) {
+        print "hooks = true"
       }
     }
   ' "$file" > "$tmp"
@@ -401,7 +401,7 @@ if [ "$WITH_HOOKS" = "1" ]; then
   mv "${HOOKS_JSON}.tmp" "$HOOKS_JSON"
 
   backup_file "$CODEX_CONFIG"
-  ensure_codex_hooks_feature "$CODEX_CONFIG"
+  ensure_hooks_feature "$CODEX_CONFIG"
 fi
 
 backup_file "$CONFIG_FILE"

--- a/tests/smoke/test-installers.sh
+++ b/tests/smoke/test-installers.sh
@@ -54,6 +54,18 @@ grep -q '^SCUTTLEBOT_RELAY_ENABLED=1$' "$SCUTTLEBOT_CONFIG_FILE"
 
 # Codex with --with-hooks
 printf 'Testing Codex installer (--with-hooks)...\n'
+mkdir -p "$HOME/.codex"
+cat > "$CODEX_CONFIG_TOML" <<'EOF'
+model = "gpt-test"
+
+[features]
+codex_hooks = false
+hooks = false
+web_search = true
+
+[mcp_servers.example]
+command = "example"
+EOF
 bash "$REPO_ROOT/skills/openai-relay/scripts/install-codex-relay.sh" \
   --url http://localhost:8080 \
   --token "test-token" \
@@ -65,6 +77,11 @@ bash "$REPO_ROOT/skills/openai-relay/scripts/install-codex-relay.sh" \
 [ -f "$HOME/.codex/hooks/scuttlebot-check.sh" ]
 [ -f "$HOME/.codex/hooks.json" ]
 [ -f "$HOME/.codex/config.toml" ]
+grep -q '^hooks = true$' "$CODEX_CONFIG_TOML"
+[ "$(grep -c '^hooks = true$' "$CODEX_CONFIG_TOML")" -eq 1 ]
+! grep -q '^[[:space:]]*codex_hooks[[:space:]]*=' "$CODEX_CONFIG_TOML"
+grep -q '^web_search = true$' "$CODEX_CONFIG_TOML"
+grep -q '^command = "example"$' "$CODEX_CONFIG_TOML"
 
 # 2. Gemini — default (hooks skipped)
 printf 'Testing Gemini installer (default, no hooks)...\n'


### PR DESCRIPTION
## Summary

- enable the supported `features.hooks` flag for Codex relay hook installs
- migrate and deduplicate legacy `codex_hooks` entries in existing config
- update relay documentation and add installer regression coverage

## Tests

- `make test-smoke`
- `go test ./...`
- `git diff --check`