### PR TITLE
fix: prepare relay CLI v1.6.0 release

### DIFF
--- a/cmd/claude-relay/main.go
+++ b/cmd/claude-relay/main.go
@@ -433,13 +433,14 @@ func mirrorSessionLoop(ctx context.Context, relay sessionrelay.Connector, filter
 // Claude Code creates the .jsonl lazily — only after the first user interaction —
 // so there is no meaningful deadline to impose. We scan every 250ms in three
 // concentric tiers:
-//   1. Primary:   ~/.claude/projects/<sanitized-cwd>/<our-uuid>.jsonl
-//   2. Sibling:   any .jsonl in ~/.claude/projects/<sanitized-cwd>/ newer than startedAt
-//                 (handles Claude Code versions that ignore --session-id)
-//   3. Cross-dir: any .jsonl under ~/.claude/projects/<*>/ newer than startedAt
-//                 (handles Claude Code versions that pick a different cwd
-//                 encoding — e.g. ".../home-leomata" vs ".../-home-leomata",
-//                 or that resolve symlinks before encoding)
+//  1. Primary:   ~/.claude/projects/<sanitized-cwd>/<our-uuid>.jsonl
+//  2. Sibling:   any .jsonl in ~/.claude/projects/<sanitized-cwd>/ newer than startedAt
+//     (handles Claude Code versions that ignore --session-id)
+//  3. Cross-dir: any .jsonl under ~/.claude/projects/<*>/ newer than startedAt
+//     (handles Claude Code versions that pick a different cwd
+//     encoding — e.g. ".../home-leomata" vs ".../-home-leomata",
+//     or that resolve symlinks before encoding)
+//
 // The cross-dir scan is intentionally last and time-bounded so we don't pick
 // up an unrelated user's stale session — only files written *after* the relay
 // started are eligible.
@@ -1652,12 +1653,12 @@ func defaultSessionID(target string) string {
 // "<user>-<cli><tier>-<session>" — e.g. "leomata-claudeb-3t8b0q" for
 // claude-relay running in an agent-browser pod for user "leomata".
 //
-//   user    : $JUPYTERHUB_USER, falling back to basename(cwd)
-//   cli     : binary name short (claude / codex / gemini)
-//   tier    : last char of the middle segment of $JUPYTERHUB_SERVER_NAME
-//             (e.g. "agnb" → "b", "agnd" → "d", "agnt" → "t", "sbot" → "t",
-//             "ide-x" → "e"). Empty when not running under JupyterHub.
-//   session : the relay's SessionID (already-sanitised crc32 / uuid prefix).
+//	user    : $JUPYTERHUB_USER, falling back to basename(cwd)
+//	cli     : binary name short (claude / codex / gemini)
+//	tier    : last char of the middle segment of $JUPYTERHUB_SERVER_NAME
+//	          (e.g. "agnb" → "b", "agnd" → "d", "agnt" → "t", "sbot" → "t",
+//	          "ide-x" → "e"). Empty when not running under JupyterHub.
+//	session : the relay's SessionID (already-sanitised crc32 / uuid prefix).
 //
 // All inputs pass through sanitize() so the output is IRC-nick-safe.
 func defaultRelayNick(cli, target, sessionID string) string {
@@ -1794,6 +1795,7 @@ func (rc *repoConfig) envOverrides() map[string]string {
 //   - dotfile to keep the file out of `ls` output
 //   - visible form for tooling globs that skip dotfiles
 //   - .yml for projects standardized on the short extension
+//
 // Whichever lands first wins; we don't merge across them.
 var repoConfigFilenames = []string{
 	".scuttlebot.yaml",

--- a/cmd/codex-relay/main.go
+++ b/cmd/codex-relay/main.go
@@ -1039,31 +1039,10 @@ func defaultSessionID(target string) string {
 }
 
 // defaultRelayNick formats the per-spawn IRC nick as
-// "<user>-<cli><tier>-<session>" — see claude-relay/main.go for the full
-// shape. Duplicated across relay binaries to avoid pulling them into a
-// shared package for one helper.
+// "<cli>-<repo>-<session>" so runtime prefixes remain easy to scan and
+// match the relay's documented addressing convention.
 func defaultRelayNick(cli, target, sessionID string) string {
-	user := os.Getenv("JUPYTERHUB_USER")
-	if user == "" {
-		user = filepath.Base(target)
-	}
-	tier := ""
-	if name := os.Getenv("JUPYTERHUB_SERVER_NAME"); name != "" {
-		parts := strings.Split(name, "-")
-		var shortcode string
-		if len(parts) >= 3 {
-			shortcode = parts[1]
-		} else if len(parts) == 2 {
-			shortcode = parts[1]
-		}
-		if shortcode != "" {
-			last := shortcode[len(shortcode)-1:]
-			if last >= "a" && last <= "z" {
-				tier = last
-			}
-		}
-	}
-	return fmt.Sprintf("%s-%s%s-%s", sanitize(user), cli, tier, sessionID)
+	return fmt.Sprintf("%s-%s-%s", cli, sanitize(filepath.Base(target)), sessionID)
 }
 
 func mirrorSessionLoop(ctx context.Context, relay sessionrelay.Connector, filtered *sessionrelay.FilteredConnector, cfg config, startedAt time.Time, preExisting map[string]struct{}, ptyDedup *relaymirror.PTYMirror) {

--- a/cmd/codex-relay/main_test.go
+++ b/cmd/codex-relay/main_test.go
@@ -58,6 +58,17 @@ func TestTargetCWD(t *testing.T) {
 	}
 }
 
+func TestDefaultRelayNickKeepsCodexPrefixFirst(t *testing.T) {
+	t.Setenv("JUPYTERHUB_USER", "astrolift")
+	t.Setenv("JUPYTERHUB_SERVER_NAME", "astrolift-agnb-terminal")
+
+	got := defaultRelayNick("codex", "/work/astrolift", "3349b971")
+	want := "codex-astrolift-3349b971"
+	if got != want {
+		t.Fatalf("defaultRelayNick = %q, want %q", got, want)
+	}
+}
+
 func TestRelayStateShouldInterruptOnlyWhenRecentlyBusy(t *testing.T) {
 	t.Helper()
 

--- a/internal/auth/apikeys_test.go
+++ b/internal/auth/apikeys_test.go
@@ -44,6 +44,7 @@ func TestCreateWithTeam(t *testing.T) {
 	looked := s.Lookup(tok2)
 	if looked == nil {
 		t.Fatal("lookup returned nil")
+		return
 	}
 	if looked.Team != "alpha" {
 		t.Errorf("lookup: expected team %q, got %q", "alpha", looked.Team)
@@ -115,6 +116,7 @@ func TestTestStoreWithTeam(t *testing.T) {
 	admin := s.Lookup("admin-tok")
 	if admin == nil {
 		t.Fatal("admin key not found")
+		return
 	}
 	if admin.Team != "" {
 		t.Errorf("admin key should have no team, got %q", admin.Team)
@@ -123,6 +125,7 @@ func TestTestStoreWithTeam(t *testing.T) {
 	team := s.Lookup("team-tok")
 	if team == nil {
 		t.Fatal("team key not found")
+		return
 	}
 	if team.Team != "alpha" {
 		t.Errorf("team key: expected team %q, got %q", "alpha", team.Team)

--- a/internal/bots/cmdparse/cmdparse_test.go
+++ b/internal/bots/cmdparse/cmdparse_test.go
@@ -33,6 +33,7 @@ func TestDM_BasicCommand(t *testing.T) {
 	reply := r.Dispatch("alice", "scroll", "replay #general last=10")
 	if reply == nil {
 		t.Fatal("expected reply, got nil")
+		return
 	}
 	if reply.Target != "alice" {
 		t.Errorf("target = %q, want %q", reply.Target, "alice")
@@ -47,6 +48,7 @@ func TestDM_CaseInsensitive(t *testing.T) {
 	reply := r.Dispatch("alice", "scroll", "REPLAY #general")
 	if reply == nil {
 		t.Fatal("expected reply, got nil")
+		return
 	}
 	if reply.Text != "replaying: #general" {
 		t.Errorf("text = %q, want %q", reply.Text, "replaying: #general")
@@ -58,6 +60,7 @@ func TestDM_NoArgs(t *testing.T) {
 	reply := r.Dispatch("alice", "scroll", "status")
 	if reply == nil {
 		t.Fatal("expected reply, got nil")
+		return
 	}
 	if reply.Text != "ok" {
 		t.Errorf("text = %q, want %q", reply.Text, "ok")
@@ -114,6 +117,7 @@ func TestFantasy_BasicCommand(t *testing.T) {
 	reply := r.Dispatch("alice", "#general", "!replay #logs last=20")
 	if reply == nil {
 		t.Fatal("expected reply, got nil")
+		return
 	}
 	if reply.Target != "#general" {
 		t.Errorf("target = %q, want %q", reply.Target, "#general")
@@ -128,6 +132,7 @@ func TestFantasy_CaseInsensitive(t *testing.T) {
 	reply := r.Dispatch("alice", "#general", "!STATUS")
 	if reply == nil {
 		t.Fatal("expected reply, got nil")
+		return
 	}
 	if reply.Text != "ok" {
 		t.Errorf("text = %q, want %q", reply.Text, "ok")
@@ -181,6 +186,7 @@ func TestAddressed_ColonSpace(t *testing.T) {
 	reply := r.Dispatch("alice", "#general", "scroll: replay #logs")
 	if reply == nil {
 		t.Fatal("expected reply, got nil")
+		return
 	}
 	if reply.Target != "#general" {
 		t.Errorf("target = %q, want %q", reply.Target, "#general")
@@ -195,6 +201,7 @@ func TestAddressed_ColonNoSpace(t *testing.T) {
 	reply := r.Dispatch("alice", "#general", "scroll:replay #logs")
 	if reply == nil {
 		t.Fatal("expected reply, got nil")
+		return
 	}
 	if reply.Text != "replaying: #logs" {
 		t.Errorf("text = %q, want %q", reply.Text, "replaying: #logs")
@@ -206,6 +213,7 @@ func TestAddressed_Comma(t *testing.T) {
 	reply := r.Dispatch("alice", "#general", "scroll, status")
 	if reply == nil {
 		t.Fatal("expected reply, got nil")
+		return
 	}
 	if reply.Text != "ok" {
 		t.Errorf("text = %q, want %q", reply.Text, "ok")
@@ -217,6 +225,7 @@ func TestAddressed_CaseInsensitiveBotNick(t *testing.T) {
 	reply := r.Dispatch("alice", "#general", "Scroll: status")
 	if reply == nil {
 		t.Fatal("expected reply, got nil")
+		return
 	}
 	if reply.Text != "ok" {
 		t.Errorf("text = %q, want %q", reply.Text, "ok")
@@ -254,6 +263,7 @@ func TestHelp_DM(t *testing.T) {
 	reply := r.Dispatch("alice", "scroll", "help")
 	if reply == nil {
 		t.Fatal("expected reply, got nil")
+		return
 	}
 	if reply.Target != "alice" {
 		t.Errorf("target = %q, want %q", reply.Target, "alice")
@@ -274,6 +284,7 @@ func TestHelp_Fantasy(t *testing.T) {
 	reply := r.Dispatch("alice", "#general", "!help")
 	if reply == nil {
 		t.Fatal("expected reply, got nil")
+		return
 	}
 	if reply.Target != "#general" {
 		t.Errorf("target = %q, want %q", reply.Target, "#general")
@@ -288,6 +299,7 @@ func TestHelp_Addressed(t *testing.T) {
 	reply := r.Dispatch("alice", "#general", "scroll: help")
 	if reply == nil {
 		t.Fatal("expected reply, got nil")
+		return
 	}
 	if reply.Target != "#general" {
 		t.Errorf("target = %q, want %q", reply.Target, "#general")
@@ -299,6 +311,7 @@ func TestHelp_SpecificCommand(t *testing.T) {
 	reply := r.Dispatch("alice", "scroll", "help replay")
 	if reply == nil {
 		t.Fatal("expected reply, got nil")
+		return
 	}
 	if !strings.Contains(reply.Text, "replay channel history") {
 		t.Errorf("help replay should show description, got: %s", reply.Text)
@@ -313,6 +326,7 @@ func TestHelp_SpecificCommandCaseInsensitive(t *testing.T) {
 	reply := r.Dispatch("alice", "scroll", "HELP REPLAY")
 	if reply == nil {
 		t.Fatal("expected reply, got nil")
+		return
 	}
 	if !strings.Contains(reply.Text, "replay channel history") {
 		t.Errorf("expected description, got: %s", reply.Text)
@@ -324,6 +338,7 @@ func TestHelp_UnknownCommand(t *testing.T) {
 	reply := r.Dispatch("alice", "scroll", "help nosuchcmd")
 	if reply == nil {
 		t.Fatal("expected reply, got nil")
+		return
 	}
 	if !strings.Contains(reply.Text, "unknown command") {
 		t.Errorf("expected unknown command message, got: %s", reply.Text)
@@ -337,6 +352,7 @@ func TestUnknown_DM(t *testing.T) {
 	reply := r.Dispatch("alice", "scroll", "frobnicate something")
 	if reply == nil {
 		t.Fatal("expected reply, got nil")
+		return
 	}
 	if !strings.Contains(reply.Text, `unknown command "frobnicate"`) {
 		t.Errorf("expected unknown command message, got: %s", reply.Text)
@@ -354,6 +370,7 @@ func TestUnknown_Fantasy(t *testing.T) {
 	reply := r.Dispatch("alice", "#general", "!frobnicate")
 	if reply == nil {
 		t.Fatal("expected reply, got nil")
+		return
 	}
 	if reply.Target != "#general" {
 		t.Errorf("target = %q, want %q", reply.Target, "#general")
@@ -368,6 +385,7 @@ func TestUnknown_Addressed(t *testing.T) {
 	reply := r.Dispatch("alice", "#general", "scroll: frobnicate")
 	if reply == nil {
 		t.Fatal("expected reply, got nil")
+		return
 	}
 	if !strings.Contains(reply.Text, `unknown command "frobnicate"`) {
 		t.Errorf("expected unknown command message, got: %s", reply.Text)
@@ -414,6 +432,7 @@ func TestLeadingTrailingWhitespace(t *testing.T) {
 	reply := r.Dispatch("alice", "scroll", "  status  ")
 	if reply == nil {
 		t.Fatal("expected reply, got nil")
+		return
 	}
 	if reply.Text != "ok" {
 		t.Errorf("text = %q, want %q", reply.Text, "ok")
@@ -428,6 +447,7 @@ func TestGreet_Addressed(t *testing.T) {
 	reply := r.Dispatch("alice", "#general", "scroll: hi")
 	if reply == nil {
 		t.Fatal("expected reply, got nil")
+		return
 	}
 	if reply.Target != "#general" {
 		t.Errorf("target = %q, want %q", reply.Target, "#general")
@@ -448,6 +468,7 @@ func TestGreet_DM_NoPurpose(t *testing.T) {
 	reply := r.Dispatch("alice", "scroll", "hello")
 	if reply == nil {
 		t.Fatal("expected reply, got nil")
+		return
 	}
 	if !strings.Contains(reply.Text, "hi alice") {
 		t.Errorf("expected greeting, got: %s", reply.Text)
@@ -491,6 +512,7 @@ func TestBridgePrefix_StrippedAndAddressingMatches(t *testing.T) {
 	reply := r.Dispatch("bridge", "#general", "[glen] scroll: status")
 	if reply == nil {
 		t.Fatal("expected reply, got nil")
+		return
 	}
 	if reply.Text != "ok" {
 		t.Errorf("text = %q, want %q", reply.Text, "ok")
@@ -502,6 +524,7 @@ func TestBridgePrefix_PreservesRealNickInGreeting(t *testing.T) {
 	reply := r.Dispatch("bridge", "#general", "[alice] scroll: hi")
 	if reply == nil {
 		t.Fatal("expected reply, got nil")
+		return
 	}
 	if !strings.Contains(reply.Text, "hi alice") {
 		t.Errorf("expected greeting to use real nick alice, got: %s", reply.Text)
@@ -523,6 +546,7 @@ func TestHelp_IncludesPurpose(t *testing.T) {
 	reply := r.Dispatch("alice", "scroll", "help")
 	if reply == nil {
 		t.Fatal("expected reply, got nil")
+		return
 	}
 	if !strings.Contains(reply.Text, "history-replay bot") {
 		t.Errorf("expected HELP to include purpose, got: %s", reply.Text)

--- a/internal/bots/oracle/oracle.go
+++ b/internal/bots/oracle/oracle.go
@@ -226,7 +226,7 @@ func (b *Bot) Start(ctx context.Context) error {
 		// DM path. Trap greetings and HELP before the strict summarize parser
 		// so a user typing "hi" doesn't see "usage: summarize ...".
 		if isGreetOrHelp(text) {
-			cl.Cmd.Notice(nick, fmt.Sprintf("oracle here — I summarise IRC channel history. Try: summarize #channel [last=N] [format=toon|json]"))
+			cl.Cmd.Notice(nick, "oracle here — I summarise IRC channel history. Try: summarize #channel [last=N] [format=toon|json]")
 			return
 		}
 

--- a/internal/bots/scroll/scroll.go
+++ b/internal/bots/scroll/scroll.go
@@ -130,7 +130,7 @@ func (b *Bot) Start(ctx context.Context) error {
 
 		// DM path: trap greetings before the strict replay parser.
 		if isGreetOrHelp(text) {
-			client.Cmd.Notice(nick, fmt.Sprintf("scroll here — I replay channel history. Try: replay #channel [last=N] [since=<unix_ms>] [format=json|toon]"))
+			client.Cmd.Notice(nick, "scroll here — I replay channel history. Try: replay #channel [last=N] [since=<unix_ms>] [format=json|toon]")
 			return
 		}
 		b.handle(client, nick, text)

--- a/pkg/relaymirror/session.go
+++ b/pkg/relaymirror/session.go
@@ -183,9 +183,9 @@ type GeminiSession struct {
 //
 //   - JSONL (Gemini CLI ≥0.40, file extension .jsonl): one object per line.
 //     Mix of:
-//       header  → {"sessionId":"...","projectHash":"...","kind":"main"}
-//       message → {"id":"...","timestamp":"...","type":"user|gemini|info","content":...}
-//       update  → {"$set":{"lastUpdated":"..."}}
+//     header  → {"sessionId":"...","projectHash":"...","kind":"main"}
+//     message → {"id":"...","timestamp":"...","type":"user|gemini|info","content":...}
+//     update  → {"$set":{"lastUpdated":"..."}}
 //     We only collect lines carrying a "type" field; the header and $set
 //     bookkeeping rows are skipped.
 func PollGeminiSession(path string, sinceIdx int) ([]GeminiMessage, int, error) {


### PR DESCRIPTION
## Summary

- restore Codex session nicks to `codex-{repo}-{session}`
- add a regression test for `codex-astrolift-3349b971` under JupyterHub env
- apply current `gofmt` formatting and remove redundant `fmt.Sprintf` calls
- guard nil test results before dereferencing so the complete staticcheck pass is clean

## Tests

- `go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run --max-issues-per-linter=0 --max-same-issues=0`
- `go test ./...`
- `make test-smoke`
- `git diff --check`